### PR TITLE
Fix: move to hatch scripts for tests and move to pytest

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,21 @@
+name: Run pyos meta tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version:
+            3.10
+      - name: Install Hatch
+        run: pipx install hatch
+      - name: Run tests
+        run: hatch run test:run-tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version:
-            3.10
+          python-version: "3.10"
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 * Enh: Use `hatch_vcs` for dynamic versioning (@lwasser, #82)
-
+* Fix: migrate to pytest for tests and setup hatch scripts (#89, @lwasser)
 
 ## v.0.2
+lots of stuff here... :) none of it documented

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Contributions of any kind welcome!
 
 [CONTRIBUTING.md](./CONTRIBUTING.md)
 
+## Development
+
+[Development guide](./development.md)
+
 ## Change log
 
 [CHANGELOG.md](./CHANGELOG.md)

--- a/development.md
+++ b/development.md
@@ -1,0 +1,17 @@
+# Development Guide
+
+## Packaging
+
+pyosMeta uses hatch and hatchling as it's build back end.
+
+## Running tests
+
+To install tests:
+
+`python -m pip install ".[tests]"`
+
+We use Hatch scripts to automate workflows.
+
+To run tests, you can use:
+
+`hatch run test:run-tests`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,7 @@ maintainers = [
 ]
 
 classifiers = [
-    # How mature is this project? Common values are
-    #   3 - Alpha
-    #   4 - Beta
-    #   5 - Production/Stable
     "Development Status :: 4 - Beta",
-
-    # Indicate who your project is intended for
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
 
@@ -50,15 +44,11 @@ license = { text = "MIT" }
 
 [project.optional-dependencies]
 dev = [
-  "pre-commit",
-  "hatch"
+  "pre-commit"
 ]
-# Examples listed include a pattern for specifying where the package tracks
-# issues, where the source is hosted, where to say thanks to the package
-# maintainers, and where to support the project financially. The key is
-# what's used to render the link text on PyPI.
+
 [project.urls]
-"Homepage" = "https://www.pyopensci.org"
+"Homepage" = "https://github.com/pyopensci/pyosmeta/"
 "Bug Reports" = "https://github.com/pyopensci/pyosmeta/issues"
 "Source" = "https://github.com/pyopensci/pyosmeta/issues"
 
@@ -75,6 +65,21 @@ update-review-teams = "pyosmeta.cli.update_review_teams:main"
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/pyosmeta/_version.py"
 
+### Hatch config ###
+
+[tool.hatch.envs.test]
+dependencies = [
+  "pytest",
+  "pytest-cov",
+]
+
+[tool.hatch.envs.test.scripts]
+#run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"
+#run = "run-coverage --no-cov"
+run-tests = "pytest"
+
+
+[tool.hatch.version]
 [tool.black]
 line-length = 79
 target-version = ['py310']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,11 @@ update-contributors = "pyosmeta.cli.update_contributors:main"
 update-reviews = "pyosmeta.cli.process_reviews:main"
 update-review-teams = "pyosmeta.cli.update_review_teams:main"
 
+### Hatch config ###
+
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/pyosmeta/_version.py"
-
-### Hatch config ###
 
 [tool.hatch.envs.test]
 dependencies = [
@@ -78,8 +78,6 @@ dependencies = [
 #run = "run-coverage --no-cov"
 run-tests = "pytest"
 
-
-[tool.hatch.version]
 [tool.black]
 line-length = 79
 target-version = ['py310']

--- a/src/tests/test_parse_user_names.py
+++ b/src/tests/test_parse_user_names.py
@@ -1,27 +1,22 @@
-from unittest import TestCase
+import pytest
 
 from pyosmeta.parse_issues import parse_user_names
 
 
-class TestParseUserNames(TestCase):
-    def setUp(self) -> None:
-        self.name1 = "Test User (@test1user)"
-        self.name2 = "(@test2user)"
-        self.name3 = "Test (user) 3 (@test3user)"
-        self.name4 = "@test4user"
-
-    def test_parse_1(self):
-        d = {"name": "Test User", "github_username": "test1user"}
-        self.assertDictEqual(d, parse_user_names(self.name1))
-
-    def test_parse_2(self):
-        d = {"name": "", "github_username": "test2user"}
-        self.assertDictEqual(d, parse_user_names(self.name2))
-
-    def test_parse_3(self):
-        d = {"name": "Test user 3", "github_username": "test3user"}
-        self.assertDictEqual(d, parse_user_names(self.name3))
-
-    def test_parse_4(self):
-        d = {"name": "", "github_username": "test4user"}
-        self.assertDictEqual(d, parse_user_names(self.name4))
+@pytest.mark.parametrize(
+    "name, expected_result",
+    [
+        (
+            "Test User (@test1user)",
+            {"name": "Test User", "github_username": "test1user"},
+        ),
+        ("(@test2user)", {"name": "", "github_username": "test2user"}),
+        (
+            "Test (user) 3 (@test3user)",
+            {"name": "Test user 3", "github_username": "test3user"},
+        ),
+        ("@test4user", {"name": "", "github_username": "test4user"}),
+    ],
+)
+def test_parse_user_names(name, expected_result):
+    assert parse_user_names(name) == expected_result


### PR DESCRIPTION
closes #89 

This is a small PR to begin moving to hatch scripts for easier test runs and automation. 
i also moved us over to pytest to take advantage of pytest.parametrize 