### PR TITLE
Bump black pre-commit hook and update file formats for black 2024 style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/psf/black
-    rev: 23.12.0
+    rev: 24.2.0
     hooks:
       - id: black
 

--- a/src/pyosmeta/cli/update_review_teams.py
+++ b/src/pyosmeta/cli/update_review_teams.py
@@ -20,6 +20,7 @@ To run: update_reviewers
 # this as will biocypher
 
 """
+
 import os
 from datetime import datetime
 

--- a/src/pyosmeta/contributors.py
+++ b/src/pyosmeta/contributors.py
@@ -444,11 +444,11 @@ class ProcessContributors:
             if gh_user in webDict.keys():
                 # Return a list of updated contributor type keys and use it to
                 # update the web dict
-                webDict[gh_user][
-                    "contributor_type"
-                ] = self._update_contrib_type(
-                    webDict[gh_user]["contributor_type"],
-                    repoDict[gh_user]["contributor_type"],
+                webDict[gh_user]["contributor_type"] = (
+                    self._update_contrib_type(
+                        webDict[gh_user]["contributor_type"],
+                        repoDict[gh_user]["contributor_type"],
+                    )
                 )
 
             # If the user is not in the web dict, add them

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -537,9 +537,9 @@ class ProcessIssues:
             pattern = r"[\(\)\[\]?]"
             owner = re.sub(pattern, "", owner)
             repo = re.sub(pattern, "", repo)
-            all_repos[
-                a_package
-            ] = f"https://api.github.com/repos/{owner}/{repo}"
+            all_repos[a_package] = (
+                f"https://api.github.com/repos/{owner}/{repo}"
+            )
         return all_repos
 
     def parse_comment(self, issue: dict[str, str]) -> tuple[str, list[str]]:


### PR DESCRIPTION
This PR updates the pre-commit hook for black to 24.2.0. Black 24.1 introduced the stable style for 2024. This PR also fixes the files that need updating to that style.