### PR TITLE
Remove unneeded file now that hatch is used for packaging

### DIFF
--- a/src/pyosmeta/__about__.py
+++ b/src/pyosmeta/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present Leah Wasser <leah@pyopensci.org>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "0.0.1"


### PR DESCRIPTION
Removes `__about__.py` that is no longer needed to set a version.