### PR TITLE
Update gitignore, flake8, and pre-commit config files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,9 @@
 [flake8]
-ignore = E203, W503
+# Ignore
+# E203: whitespace before `,` `;` or `:`
+# E266: too many leading # for block comment
+# E501: line too long
+# E701: Multiple statements on one line (colon)
+# W503: line break after binary operator
+ignore = E203, E266, E501, E701, E704, W503
+max-complexity = 18

--- a/.gitignore
+++ b/.gitignore
@@ -166,19 +166,7 @@ cython_debug/
 .vscode/
 
 # pyosMeta specific
-all_contribs.pickle
-all_contribs_dict.pickle
-all-submissions.csv
-issue-stats.ipynb
-plot.py
-presubmissions.csv
-reviews_all.csv
-reviews_presubmissions.csv
 src/pyosmeta/_version.py
-src/pyosmeta/cli/test.ipynb
-
-contrib*.yml
-pack*.yml
 *.pickle
 
 .token

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,123 @@
-.DS_Store
-contrib*.yml
-pack*.yml
-*.pickle
-all_contribs.pickle
-all_contribs_dict.pickle
-.env
-.vscode/
-.idea/
-.token
-__pycache__
-.coverage
-coverage.xml
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
+# C extensions
+*.so
 
 # Distribution / packaging
 .Python
 build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
 
 # pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
 .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
 
 # Environments
 .env
@@ -30,19 +128,58 @@ ENV/
 env.bak/
 venv.bak/
 
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
 # mypy
 .mypy_cache/
 .dmypy.json
 dmypy.json
 
-token.txt
-src/pyosmeta/_version.py
+# Pyre type checker
+.pyre/
 
-# local files
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# macOS
+.DS_Store
+
+# vscode editor
+.vscode/
+
+# pyosMeta specific
+all_contribs.pickle
+all_contribs_dict.pickle
 all-submissions.csv
 issue-stats.ipynb
 plot.py
 presubmissions.csv
 reviews_all.csv
 reviews_presubmissions.csv
+src/pyosmeta/_version.py
 src/pyosmeta/cli/test.ipynb
+
+contrib*.yml
+pack*.yml
+*.pickle
+
+.token
+token.txt

--- a/.gitignore
+++ b/.gitignore
@@ -132,11 +132,6 @@ venv.bak/
 .spyderproject
 .spyproject
 
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
 
 # mypy
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -112,12 +112,6 @@ ipython_config.py
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -109,8 +109,6 @@ ipython_config.py
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
 
 
 # Environments

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,37 +1,35 @@
-# pre-commit is a tool that you run locally
-# to perform a predefined set of tasks manually and/or
-# automatically before git commits are made.
-# Here we are using pre-commit with the precommit.ci bot to implement
-# code fixes automagically in pr's. You will still want to install pre-commit
-# to run locally
-# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
-# To run on a pr, add a comment with the text "pre-commit.ci run"
-# Common tasks
-#
-# - Run on all files:   pre-commit run --all-files
-# - Register git hooks: pre-commit install --install-hooks
+# pre-commit (https://pre-commit.com/) is a tool that runs source code checks
+# such as linting, formatting, and code style.
+
+# CI
+# pyosMeta uses pre-commit with the precommit.ci bot to check pull requests.
+# Configuration reference doc: https://pre-commit.com/#pre-commit-configyaml---top-level
+
+# Developers
+# You may want to install pre-commit to run locally on each minimum_pre_commit_version
+# See https://pre-commit.com/#install
+# To set up pre-commit hooks: pre-commit install
+# To run on all files: pre-commit run --all-files
 
 ci:
+  # pyosMeta disables autofixing of PRs to simplify new contributor experience and cleaner git history
   autofix_prs: false
-  #skip: [flake8, end-of-file-fixer]
-  autofix_commit_msg: |
-    '[pre-commit.ci 🤖] Apply code format tools to PR'
-  # Update hook versions every quarter (so we don't get hit with weekly update pr's)
+  # Frequency of hook updates
   autoupdate_schedule: weekly
 
 repos:
-  # Misc commit checks
+  # Out of the box hooks for pre-commit https://github.com/pre-commit/pre-commit-hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
-    # ref: https://github.com/pre-commit/pre-commit-hooks#hooks-available
     hooks:
-      # Autoformat: Makes sure files end in a newline and only a newline.
+      # Makes sure files end in a newline and only a newline.
       - id: end-of-file-fixer
-      # Lint: Check for files with names that would conflict on a
-      # case-insensitive filesystem like MacOS HFS+ or Windows FAT.
+      # Check for files with names that would conflict on a case-insensitive filesystem like MacOS HFS+ or Windows FAT.
       - id: check-case-conflict
+      # Remove trailing whitespace on code lines
       - id: trailing-whitespace
 
+  # Spelling hook
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:
@@ -39,17 +37,19 @@ repos:
         additional_dependencies:
           - tomli
 
-  # Linting: Python code (see the file .flake8)
+  # Linting hook for Python code (see the file .flake8)
   - repo: https://github.com/PyCQA/flake8
     rev: "7.0.0"
     hooks:
       - id: flake8
 
+  # Code formatting hook
   - repo: https://github.com/psf/black
     rev: 24.2.0
     hooks:
       - id: black
 
+  # Best practice style for module imports
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
Addresses #78.

This PR updates and documents the following configuration files:
- .gitignore (use standard Python gitignore and move pyosMeta specific items to end)
- .flake8 (explain ignored rules and add a code complexity check)
- .precommit.config.yaml (improve comments for maintainability and new contributor friendliness)