### PR TITLE
Update optional dependencies and edit pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [{ name = "Leah Wasser", email = "leah@pyopensci.org" }]
 maintainers = [
     { name = "pyOpenSci", email = "admin@pyopensci.org" }, # Optional
 ]
-
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -24,34 +23,30 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-
-
 dependencies = [
-    "ruamel-yaml>=0.17.21",
-    "requests",
-    "python-dotenv",
     "pydantic>=2.0",
+    "python-dotenv",
     "requests",
-    "python-dotenv"
+    "ruamel-yaml>=0.17.21",
 ]
-
-
-# This is the metadata that pip reads to understand what versions your package supports
+# This is metadata that pip reads to understand what Python versions your package supports
 requires-python = ">=3.10"
 readme = "README.md"
 license = { text = "MIT" }
 
-
 [project.optional-dependencies]
 dev = [
-  "pre-commit"
+    "black",
+    "flake8",
+    "pre-commit",
+    "pytest",
+    "pytest-cov"
 ]
 
 [project.urls]
 "Homepage" = "https://github.com/pyopensci/pyosmeta/"
 "Bug Reports" = "https://github.com/pyopensci/pyosmeta/issues"
 "Source" = "https://github.com/pyopensci/pyosmeta/issues"
-
 
 # These are entry points that allow you to surface specific functionality
 # for a user to run directly from the package.
@@ -60,6 +55,7 @@ parse-history = "pyosmeta.cli.parse_history:main"
 update-contributors = "pyosmeta.cli.update_contributors:main"
 update-reviews = "pyosmeta.cli.process_reviews:main"
 update-review-teams = "pyosmeta.cli.update_review_teams:main"
+
 
 ### Hatch config ###
 
@@ -77,6 +73,9 @@ dependencies = [
 #run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"
 #run = "run-coverage --no-cov"
 run-tests = "pytest"
+
+
+### Tool configuration ###
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
This PR adds dev dependencies as optional dependencies and makes minor style changes.

Developers can now run `pip install ".[dev]"` or `pip install -e ".[dev]"` to install dev tools locally.

We can set up a dev environment for hatch in a separate PR.