### PR TITLE
Fix: Add categories validator to model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,3 @@
 ## [v.0.2](https://pypi.org/project/pyosmeta/0.2)
 
 2023-08-17 - Initial release to PyPI.
-
-## v.0.2
-
-lots of stuff here... :) none of it documented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ## Unreleased
 
-* Enh: Use `hatch_vcs` for dynamic versioning (@lwasser, #82)
-* Fix: migrate to pytest for tests and setup hatch scripts (#89, @lwasser)
-* Add: Partner support to package (#92, @lwasser)
+- Enh: Use `hatch_vcs` for dynamic versioning (@lwasser, #82)
+- Fix: migrate to pytest for tests and setup hatch scripts (#89, @lwasser)
+- Add: Partner support to package (#92, @lwasser)
+- Fix: Add validation step to categories attr in pydantic model (#105, @lwasser)
 
 ## [v0.15](https://github.com/pyOpenSci/pyosMeta/releases/tag/v0.15)
 
@@ -15,3 +16,7 @@
 ## [v.0.2](https://pypi.org/project/pyosmeta/0.2)
 
 2023-08-17 - Initial release to PyPI.
+
+## v.0.2
+
+lots of stuff here... :) none of it documented

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -265,6 +265,49 @@ class ReviewModel(BaseModel):
 
         return user
 
+    @field_validator(
+        "categories",
+        mode="before",
+    )
+    @classmethod
+    def clean_categories(cls, categories: list[str]) -> list[str]:
+        """Make sure each category in the list is a valid value.
+
+        Valid pyos software categories are:
+            citation-management-bibliometrics, data-retrieval,
+            data-extraction, data-processing-munging, data-deposition",
+            data-validation-testing, data-visualization-analysis,
+            workflow-automation-versioning, database-interoperability,
+            scientific-software-wrappers, geospatial, education
+
+        Parameters
+        ----------
+        categories : list[str]
+            List of categories to clean.
+
+        Returns
+        -------
+        list[str]
+            List of cleaned categories.
+        """
+
+        valid_categories = {
+            "data-processing": "data-processing-munging",
+            "scientific-software": "scientific-software-wrapper",
+            "data-validation": "data-validation-testing",
+        }
+
+        cleaned_cats = []
+        for category in categories:
+            for valid_prefix, valid_cat in valid_categories.items():
+                if category.startswith(valid_prefix):
+                    cleaned_cats.append(valid_cat)
+                    break
+            else:
+                # No match found, keep the original category
+                cleaned_cats.append(category)
+        return cleaned_cats
+
 
 @dataclass
 class ProcessIssues:

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -274,11 +274,13 @@ class ReviewModel(BaseModel):
         """Make sure each category in the list is a valid value.
 
         Valid pyos software categories are:
-            citation-management-bibliometrics, data-retrieval,
-            data-extraction, data-processing-munging, data-deposition",
+            citation-management-bibliometrics, data-deposition,
+            data-extraction, data-processing-munging, data-retrieval,
             data-validation-testing, data-visualization-analysis,
-            workflow-automation-versioning, database-interoperability,
-            scientific-software-wrappers, geospatial, education
+            database-interoperability, education,
+            geospatial, scientific-software-wrappers,
+            workflow-automation-versioning
+
 
         Parameters
         ----------
@@ -293,8 +295,8 @@ class ReviewModel(BaseModel):
 
         valid_categories = {
             "data-processing": "data-processing-munging",
-            "scientific-software": "scientific-software-wrapper",
             "data-validation": "data-validation-testing",
+            "scientific-software": "scientific-software-wrapper",
         }
 
         cleaned_cats = []

--- a/tests/unit/test_parse_categories.py
+++ b/tests/unit/test_parse_categories.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pyosmeta.parse_issues import ProcessIssues
+from pyosmeta.parse_issues import ProcessIssues, ReviewModel
 
 checked = [
     ["Submitting Author", "Nabil Freij (@nabobalis)"],
@@ -65,3 +65,37 @@ def test_get_categories(
 
     # Assert the result matches the expected categories
     assert categories == expected_categories
+
+
+@pytest.mark.parametrize(
+    "input_categories,expected_return",
+    [
+        (
+            ["data-processing"],
+            ["data-processing-munging"],
+        ),
+        (
+            ["data-processing/munging"],
+            ["data-processing-munging"],
+        ),
+        (
+            ["scientific-software and friends"],
+            ["scientific-software-wrapper"],
+        ),
+        (
+            ["data-validation and things -testing"],
+            ["data-validation-testing"],
+        ),
+        (
+            ["data-processing", "data-extraction"],
+            ["data-processing-munging", "data-extraction"],
+        ),
+    ],
+)
+def test_clean_categories(
+    input_categories: list[str], expected_return: list[str]
+):
+    """Test that ensures our pydantic model cleans categories as expected"""
+
+    review = ReviewModel(categories=input_categories)
+    assert review.categories == expected_return


### PR DESCRIPTION
closes #105 

Opening as a draft as it still needs tests but this adds a validation step to categories to ensure they are added to the final yaml file in a clean format with only dashes in between words for easier web parsing. 