### PR TITLE
Fix: Update publish pypi workflow to use hatch

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -46,10 +46,10 @@ jobs:
         with:
           # Haven't setup trusted workflow on test pypi yet
           password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
           # NOT TO BE USED in PyPI!
-          skip_existing: true
+          skip-existing: true
 
       - name: Publish package to PyPI
         # Only publish to real PyPI on release

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
   push:
     branches:
-      - master
+      - main
 jobs:
   build-publish:
     runs-on: ubuntu-latest
@@ -26,16 +26,15 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
-
-      - name: Install requirements
+          python-version: "3.10"
+      - name: Install Hatch
         run: |
-          python -m pip install -r requirements-build.txt
+          pipx install hatch
           pip list
 
-      - name: Build package using PDM
+      - name: Build package using Hatch
         run: |
-          pdm build
+          hatch build
           echo ""
           echo "Generated files:"
           ls -lh dist/
@@ -45,6 +44,7 @@ jobs:
         if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          # Haven't setup trusted workflow on test pypi yet
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
@@ -55,5 +55,3 @@ jobs:
         # Only publish to real PyPI on release
         if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: migrate to pytest for tests and setup hatch scripts (#89, @lwasser)
 - Add: Partner support to package (#92, @lwasser)
 - Fix: Add validation step to categories attr in pydantic model (#105, @lwasser)
+- Fix: update pypi publish to use hatch (#82, @lwasser)
 
 ## [v0.15](https://github.com/pyOpenSci/pyosMeta/releases/tag/v0.15)
 


### PR DESCRIPTION
this closes #100 #82

NOTE: i haven't set this up before with hatch but because hatch is using setuptools_scm i suspect it's the same workflow. let's see how this runs. 