### PR TITLE
Fix: test pypi trusted workflow setup, remove token

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -44,8 +44,6 @@ jobs:
         if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # Haven't setup trusted workflow on test pypi yet
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
           # NOT TO BE USED in PyPI!


### PR DESCRIPTION
This is a tiny pr that should fix test pypi failing (as it did on @willingc last commit). if we merge this test pypi should recieve a new build of pyos meta (which is not published there yet). 