### PR TITLE
Fix: add permissions to publish

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,6 +11,8 @@ jobs:
     # This ensures that the publish action only runs in the main repository
     # rather than forks
     if: github.repository_owner == 'pyopensci'
+    permissions:
+      id-token: write  # this permission is mandatory for pypi publishing
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#defining-a-workflow-job-environment i'm not actually sure this is the right location for these permissions. or how to test. but i can ask someone in our slack to review?? or do you know @willingc i've not had to setup such permissions before but i've also not published using trusted publisher before i've always used a token. 