### PR TITLE
Fix: field alias for date_accepted field

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -42,7 +42,7 @@ jobs:
           echo ""
           echo "Generated files:"
           ls -lh dist/
-          
+
       - name: Publish package on test PyPI on merge in main branch
         # Test push to test pypi on merge to main
         if: github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,6 @@ cython_debug/
 # pyosMeta specific
 src/pyosmeta/_version.py
 *.pickle
-
 .token
 token.txt
+_data/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add: Code coverage setup (#97, @lwasser)
 - Fix: Add validation step to categories attr in pydantic model (#105, @lwasser)
 - Fix: update pypi publish to use hatch (#82, @lwasser)
+- Fix: move data accepted cleanup to pydantic field alias / validation step (@lwasser)
 
 ## [v0.15](https://github.com/pyOpenSci/pyosMeta/releases/tag/v0.15)
 

--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -29,7 +29,7 @@ def main():
         repo_name="software-submission",
         label_name="6/pyOS-approved 🚀🚀🚀",
     )
-
+    # date_accepted_(month/day/year)
     # Get all issues for approved packages - load as dict
     issues = process_review.return_response()
     # TODO: this method parse_issue_header is working but the parsing code is

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -431,8 +431,9 @@ class ProcessIssues:
 
         Returns
         -------
-            Dict containing the metadata for a submitting author, reviewer or
-            maintainer(s)
+            Dict
+                Containing the metadata for a submitting author, reviewer or
+                maintainer(s)
         """
 
         meta = {}

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -147,24 +147,25 @@ class ReviewModel(BaseModel):
         validate_assignment=True,
     )
 
-    package_name: Optional[str] = ""
+    package_name: str | None = ""
     package_description: str = Field(
         "", validation_alias=AliasChoices("one-line_description_of_package")
     )
-    submitting_author: dict[str, Optional[str]] = {}
+    submitting_author: dict[str, str | None] = {}
     all_current_maintainers: list[dict[str, str | None]] = {}
-    repository_link: Optional[str] = None
+    repository_link: str | None = None
     version_submitted: Optional[str] = None
     categories: Optional[list[str]] = None
     editor: dict[str, str | None] = {}
     reviewer_1: dict[str, str | None] = {}
     reviewer_2: dict[str, str | None] = {}
-    archive: Optional[str] = None
-    version_accepted: Optional[str] = None
-    date_accepted: Optional[str] = Field(
+    archive: str | None = None
+    version_accepted: str | None = None
+    date_accepted: str | None = Field(
+        default=None,
         validation_alias=AliasChoices(
             "date_accepted_(month/day/year)", "Date accepted"
-        )
+        ),
     )
     created_at: str = None
     updated_at: str = None

--- a/tests/unit/test_review_model.py
+++ b/tests/unit/test_review_model.py
@@ -1,0 +1,36 @@
+from pyosmeta.parse_issues import ReviewModel
+
+# We could setup some example data using fixtures and a conf.py
+# Once we have a better view of the test suite.
+example = {
+    "submitting_author": {
+        "github_username": "nabobalis",
+        "name": "Nabil Freij",
+    },
+    "all_current_maintainers": [],
+    "package_name": "sunpy",
+    "one-line_description_of_package": "Python for Solar Physics",
+    "repository_link": "https://github.com/sunpy/sunpy",
+    "version_submitted": "5.0.1",
+    "editor": {"github_username": "cmarmo", "name": ""},
+    "reviewer_1": {"github_username": "Septaris", "name": ""},
+    "reviewer_2": {"github_username": "nutjob4life", "name": ""},
+    "archive": "[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8384174.svg)](https://doi.org/10.5281/zenodo.8384174)",
+    "version_accepted": "5.1.1",
+    "joss_doi": "[![DOI](https://joss.theoj.org/papers/10.21105/joss.01832/status.svg)](https://joss.theoj.org/papers/10.21105/joss.01832)",
+    "date_accepted_(month/day/year)": "01/18/2024",
+    "categories": [
+        "data-retrieval",
+        "data-extraction",
+        "data-processing/munging",
+        "data-visualization",
+    ],
+}
+
+
+def test_alias_choices_validation():
+    """Test that model correctly recognizes the field alias"""
+
+    new = ReviewModel(**example)
+    assert new.date_accepted == "2024-01-18"
+    assert new.package_description == "Python for Solar Physics"


### PR DESCRIPTION
Rather than fixing the entire thing i'm working towards cleaning up the parse_issues method. This is a small fix that 

1. adds a field alias to pydantic so there's not a random date field cleanup step in an unexpected place. 
2. adds a small test to ensure the both aliases defined in the model work 

i'm guessing there are better ways to setup tests like this but it's a start and i'm trying to keep this contained. this addresses #91 in (a very small) part. 