### PR TITLE
Draft February 2024 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,46 @@
 
 [![PyPI](https://img.shields.io/pypi/v/pyosmeta.svg)](https://pypi.org/project/pyosmeta/)
 
-## Unreleased
+## [Unreleased]
 
-- Enh: Use `hatch_vcs` for dynamic versioning (@lwasser, #82)
-- Fix: migrate to pytest for tests and setup hatch scripts (#89, @lwasser)
-- Add: Partner support to package (#92, @lwasser)
-- Add: Code coverage setup (#97, @lwasser)
-- Fix: Add validation step to categories attr in pydantic model (#105, @lwasser)
-- Fix: update pypi publish to use hatch (#82, @lwasser)
-- Fix: move data accepted cleanup to pydantic field alias / validation step (@lwasser)
+## [v0.2.3] - 2024-02-29
 
-## [v0.15](https://github.com/pyOpenSci/pyosMeta/releases/tag/v0.15)
+This version adds automation of our workflows, including using `hatch`
+for builds, automated GitHub actions for linting and testing, coverage reporting, and
+dynamic versioning. This release adds basic functionality for Partner support.
 
-2023-12-20 - This release was tagged in git and GitHub but not released to PyPI.
+### Added
 
-## [v.0.2](https://pypi.org/project/pyosmeta/0.2)
+- Use `hatch_vcs` for dynamic versioning (@lwasser, #82)
+- Partner support to package (#92, @lwasser)
+- Code coverage setup (#97, @lwasser)
 
-2023-08-17 - Initial release to PyPI.
+### Changed
+
+- Migrate to pytest for tests and setup hatch scripts (#89, @lwasser)
+- Add validation step to categories attr in pydantic model (#105, @lwasser)
+- Update pypi publish to use hatch (#82, @lwasser)
+- Move data accepted cleanup to pydantic field alias / validation step (@lwasser)
+
+Thank you to all contributors to this release. Special thanks
+to @ofek for assistance with `hatch`, @pradyunsg for packaging guidance, @webknjaz
+and @woodruffw for help troubleshooting Trusted Publisher releases to PyPI, and @willingc for guidance in software
+development best practices.
+
+## [v0.2.2] - 2024-02-27
+
+This version tested our production release process to PyPI.
+
+## [v0.15] - 2023-12-20
+
+This release was tagged in git and GitHub but not released to PyPI.
+
+## [v.0.2] - 2023-08-17
+
+Initial release to PyPI.
+
+[Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v0.2.3...HEAD
+[v0.2.3]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.3
+[v0.2.2]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.2
+[v0.15]: https://github.com/pyOpenSci/pyosMeta/releases/tag/v0.15
+[v.0.2]: https://pypi.org/project/pyosmeta/0.2/


### PR DESCRIPTION
This PR adopts the ["Keep a Changelog"](https://keepachangelog.com/en/1.1.0/) format. This will be useful if we decide to automate changelogs in the future. It also adds some shoutouts for contributions. The changelog itself is not comprehensive of all changes, but links to all changes.