### PR TITLE
Fix: parse up to 100 issues in a request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 [![PyPI](https://img.shields.io/pypi/v/pyosmeta.svg)](https://pypi.org/project/pyosmeta/)
 
 ## [Unreleased]
+- Parse up to 100 issues in a request (@lwasser, #94)
+
 
 ## [v0.2.3] - 2024-02-29
 

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -363,7 +363,7 @@ class ProcessIssues:
     def api_endpoint(self):
         url = (
             f"https://api.github.com/repos/{self.org}/{self.repo_name}/"
-            f"issues?labels={self.label_name}&state=all"
+            f"issues?labels={self.label_name}&state=all&per_page=100"
         )
         return url
 


### PR DESCRIPTION
This will close #94 
the simple fix to the pagination issue is to just change the api endpoint to increase from the default 30 to 100 per page. this PR implements that fix. 

In a separate fix we can add pagination.