### PR TITLE
Fix: rename util modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: Parse up to 100 issues in a request (@lwasser, #94)
 - Fix: refactor parse issue header (@lwasser, #91)
 - Fix: Refactor and organize modules (@lwasser, #76)
+- Fix: Rename and organize `clean.py` module into `utils_parse` and `utils_clean` (@lwasser, @willingc, #121)
 
 
 ## [v0.2.3] - 2024-02-29

--- a/src/pyosmeta/models.py
+++ b/src/pyosmeta/models.py
@@ -16,7 +16,7 @@ from pydantic import (
 )
 from typing import Optional, Set, Union
 
-from pyosmeta.clean import clean_date, clean_markdown
+from pyosmeta.utils_clean import clean_date, clean_markdown
 
 
 class UrlValidatorMixin:

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -5,8 +5,9 @@ import requests
 from dataclasses import dataclass
 from typing import Any
 
-from .clean import clean_markdown, parse_user_names
 from .contributors import ProcessContributors
+from .utils_clean import clean_markdown
+from .utils_parse import parse_user_names
 
 
 @dataclass

--- a/src/pyosmeta/utils_clean.py
+++ b/src/pyosmeta/utils_clean.py
@@ -41,47 +41,6 @@ def clean_name(a_str: str) -> str:
     return a_str.strip()
 
 
-def parse_user_names(username: str) -> dict[str, str]:
-    """Parses authors, contributors, editors and usernames from
-    the requested issues.
-
-    Parameters
-    ----------
-    username : str
-        The line with username (see Notes).
-
-    Returns
-    -------
-    dict
-        ``{name: str, github_username: str}``
-
-    Notes
-    -----
-    Possible combinations:
-
-    1. Name Surname (@Github_handle)
-    2. (@Github_handle)
-    3. @Github_handle
-
-    """
-    names = username.split("@", 1)
-    names = [x for x in names if len(x) > 0]
-
-    if len(names) > 1:
-        parsed = {
-            "github_username": clean_name(names[1]),
-            "name": clean_name(names[0]),
-        }
-
-    else:
-        parsed = {
-            "github_username": clean_name(names[0]),
-            "name": "",
-        }
-
-    return parsed
-
-
 def clean_markdown(txt: str) -> str:
     """
     Remove Markdown characters from the beginning or end of a string.

--- a/src/pyosmeta/utils_parse.py
+++ b/src/pyosmeta/utils_parse.py
@@ -1,0 +1,47 @@
+"""
+A small module containing functions that support parsing
+pyOpenSci review and contributor metadata.
+"""
+
+from pyosmeta.utils_clean import clean_name
+
+
+def parse_user_names(username: str) -> dict[str, str]:
+    """Parses authors, contributors, editors and usernames from
+    the requested issues.
+
+    Parameters
+    ----------
+    username : str
+        The line with username (see Notes).
+
+    Returns
+    -------
+    dict
+        ``{name: str, github_username: str}``
+
+    Notes
+    -----
+    Possible combinations:
+
+    1. Name Surname (@Github_handle)
+    2. (@Github_handle)
+    3. @Github_handle
+
+    """
+    names = username.split("@", 1)
+    names = [x for x in names if len(x) > 0]
+
+    if len(names) > 1:
+        parsed = {
+            "github_username": clean_name(names[1]),
+            "name": clean_name(names[0]),
+        }
+
+    else:
+        parsed = {
+            "github_username": clean_name(names[0]),
+            "name": "",
+        }
+
+    return parsed

--- a/tests/unit/test_parse_user_names.py
+++ b/tests/unit/test_parse_user_names.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pyosmeta.clean import parse_user_names
+from pyosmeta.utils_parse import parse_user_names
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes #121 
Here i moved parse_names to a new utils_parse.py module. i also renamed clean to utils_clean.py. i lead with utils to avoid confusing parse_utils with parse_issues and then the two utils modules sort nicely together in the package