### PR TITLE
Update github actions to resolve nodejs 16 warnings

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write  # this permission is mandatory for pypi publishing
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # This fetch element is only important if you are use SCM based
           # versioning (that looks at git tags to gather the version)
@@ -28,7 +28,7 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install Hatch

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # TODO: consider replacing python/pip/update-web-metadata installs with docker image
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
       - name: Upgrade pip
         run: |
           # install pip=>20.1 to use "pip cache dir"
@@ -20,7 +20,7 @@ jobs:
         run: python -m pip install git+https://github.com/pyopenSci/update-web-metadata
 
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run script from update-web-metadata repo
         env:
          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Partially addresses #113 

This PR makes the versions used by checkout and python actions the same across all files. This should remove the warnings seen on some workflows about NodeJS 16 deprecation.