### PR TITLE
Fix: Move all of the github things to a new module for easier maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix: Rename and organize `clean.py` module into `utils_parse` and `utils_clean` (@lwasser, @willingc, #121)
 - Fix: Add tests for all utils functions (@lwasser, #122)
 - Fix: Bug where date_accepted is removed (@lwasser, #129)
+- Fix: Refactor all GitHub related methods move to gh_client module (@lwasser, #125)
 
 
 ## [v0.2.3] - 2024-02-29

--- a/development.md
+++ b/development.md
@@ -36,8 +36,8 @@ script options that you can chose to run.
 
    `hatch run test:run-coverage`
 
-2. To run tests without code coverage report outs use :
-   `hatch run test:run-coverage`
+2. To run tests without code coverage report outs use:
+   `hatch run test:run-no-cov`
 
 3. To run tests with an xml report generated use:
    `hatch run test:run-report`

--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -35,6 +35,8 @@ def main():
     process_review = ProcessIssues(github_api)
 
     # Get all issues for approved packages - load as dict
+    # TODO: this doesn't have to be in process issues at all. it could fully
+    # Call the github module
     issues = process_review.return_response()
     accepted_reviews = process_review.parse_issue_header(issues, 45)
 

--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -21,15 +21,19 @@ import pickle
 from pydantic import ValidationError
 
 from pyosmeta import ProcessIssues, ReviewModel
+from pyosmeta.github_api import GitHubAPI
 
 
 def main():
-    process_review = ProcessIssues(
+
+    github_api = GitHubAPI(
         org="pyopensci",
-        repo_name="software-submission",
-        label_name="6/pyOS-approved 🚀🚀🚀",
+        repo="software-submission",
+        labels=["6/pyOS-approved 🚀🚀🚀"],
     )
-    # date_accepted_(month/day/year)
+
+    process_review = ProcessIssues(github_api)
+
     # Get all issues for approved packages - load as dict
     issues = process_review.return_response()
     accepted_reviews = process_review.parse_issue_header(issues, 45)

--- a/src/pyosmeta/contributors.py
+++ b/src/pyosmeta/contributors.py
@@ -1,7 +1,9 @@
 import json
+import os
 
 import requests
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from typing import List, Optional, Tuple
 
 
@@ -50,17 +52,17 @@ class ProcessContributors:
             ],
         }
 
-    # def get_token(self) -> str:
-    #     """Fetches the GitHub API key from the users environment. If running
-    #     local from an .env file.
+    def get_token(self) -> str:
+        """Fetches the GitHub API key from the users environment. If running
+        local from an .env file.
 
-    #     Returns
-    #     -------
-    #     str
-    #         The provided API key in the .env file.
-    #     """
-    #     load_dotenv()
-    #     return os.environ["GITHUB_TOKEN"]
+        Returns
+        -------
+        str
+            The provided API key in the .env file.
+        """
+        load_dotenv()
+        return os.environ["GITHUB_TOKEN"]
 
     def check_contrib_type(self, json_file: str):
         """

--- a/src/pyosmeta/contributors.py
+++ b/src/pyosmeta/contributors.py
@@ -1,9 +1,7 @@
 import json
-import os
 
 import requests
 from dataclasses import dataclass
-from dotenv import load_dotenv
 from typing import List, Optional, Tuple
 
 
@@ -52,17 +50,17 @@ class ProcessContributors:
             ],
         }
 
-    def get_token(self) -> str:
-        """Fetches the GitHub API key from the users environment. If running
-        local from an .env file.
+    # def get_token(self) -> str:
+    #     """Fetches the GitHub API key from the users environment. If running
+    #     local from an .env file.
 
-        Returns
-        -------
-        str
-            The provided API key in the .env file.
-        """
-        load_dotenv()
-        return os.environ["GITHUB_TOKEN"]
+    #     Returns
+    #     -------
+    #     str
+    #         The provided API key in the .env file.
+    #     """
+    #     load_dotenv()
+    #     return os.environ["GITHUB_TOKEN"]
 
     def check_contrib_type(self, json_file: str):
         """

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -57,9 +57,19 @@ class GitHubAPI:
         -------
         str
             The provided API key in the .env file.
+
+        Raises
+        ------
+        KeyError
+            If the GITHUB_TOKEN environment variable is not found.
         """
         load_dotenv()
-        return os.environ["GITHUB_TOKEN"]
+        try:
+            return os.environ["GITHUB_TOKEN"]
+        except KeyError:
+            raise KeyError(
+                "Oops! A GITHUB_TOKEN environment variable wasn't found."
+            )
 
     @property
     def api_endpoint(self):

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -1,0 +1,159 @@
+"""
+A module that houses all of the methods related to interfacing
+with the GitHub API. THere are three groupings of activities here:
+
+1. Parsing github issues to return peer review information
+2. Parsing contributor profile data to return names and affiliations where
+available
+3. Parsing package repositories to return package metadata such as pull request
+numbers, stars and more "health & stability" related metrics
+"""
+
+import os
+
+import requests
+from dataclasses import dataclass
+from dotenv import load_dotenv
+from typing import Any
+
+
+@dataclass
+class GitHubAPI:
+    """
+    A class that processes GitHub issues in our peer review process and returns
+    metadata about each package.
+    """
+
+    def __init__(
+        self,
+        org: str | None = None,
+        repo: str | None = None,
+        labels: list[str] | None = None,
+    ):
+        """
+        Initialize a GitHub client object that handles interfacing with the
+        GitHub API.
+
+        Parameters
+        ----------
+        org : str, Optional
+            Organization name where the issues exist
+        repo : str, Optional
+            Repo name where the software review issues live
+        labels : list of strings, Optional
+            Labels for issues that we want to access - e.g. pyos approved
+        """
+
+        self.org: str | None = org
+        self.repo: str | None = repo
+        self.labels: list[str] | None = labels
+
+    def get_token(self) -> str | None:
+        """Fetches the GitHub API key from the users environment. If running
+        local from an .env file.
+
+        Returns
+        -------
+        str
+            The provided API key in the .env file.
+        """
+        load_dotenv()
+        return os.environ["GITHUB_TOKEN"]
+
+    @property
+    def api_endpoint(self):
+        labels_query = ",".join(self.labels) if self.labels else ""
+        url = (
+            f"https://api.github.com/repos/{self.org}/{self.repo}/"
+            f"issues?labels={labels_query}&state=all&per_page=100"
+        )
+        return url
+
+    def return_response(self) -> list[dict[str, object]]:
+        """
+        Make a GET request to the Github API endpoint
+        Deserialize json response to list of dicts.
+
+        Parameters
+        ----------
+        username : str
+            GitHub username of person authenticating to hit the GitHub API
+
+        Returns
+        -------
+        list
+            List of dict items each containing a review issue
+        """
+        print(self.api_endpoint)
+
+        try:
+            response = requests.get(
+                self.api_endpoint,
+                headers={"Authorization": f"token {self.get_token()}"},
+            )
+            response.raise_for_status()
+
+        except requests.HTTPError as exception:
+            raise exception
+
+        return response.json()
+
+    # This is also github related
+    def get_repo_meta(self, url: str) -> dict[str, Any]:
+        """
+        Returns a set of GH stats from each repo of our reviewed packages.
+
+        """
+        # stats_dict = {}
+        # Get the url (normally the docs) and description of a repo
+        response = requests.get(
+            url, headers={"Authorization": f"token {self.get_token()}"}
+        )
+
+        # TODO: should this be some sort of try/except how do i catch these
+        # Response errors in the best way possible?
+        if response.status_code == 404:
+            print("Can't find: ", url, ". Did the repo url change?")
+        elif response.status_code == 403:
+            print("Oops you may have hit an API limit. Exiting")
+            print(f"API Response Text: {response.text}")
+            print(f"API Response Headers: {response.headers}")
+            exit()
+
+        else:
+            return response.json()
+
+    def get_repo_contribs(self, url: str) -> dict:
+        """
+        Returns a count for total contribs to a repo.
+        I definitely think graphQL would be better suited for these calls
+        """
+        repo_contribs = url + "/contributors"
+        # Get the url (normally the docs) and repository description
+        response = requests.get(
+            repo_contribs,
+            headers={"Authorization": f"token {self.get_token()}"},
+        )
+
+        if response.status_code == 404:
+            print("Can't find: ", repo_contribs, ". Did the repo url change?")
+        # Extract the description and homepage URL from the JSON response
+        else:
+            return len(response.json())
+
+    def get_last_commit(self, repo: str) -> str:
+        """Returns the last commit to the repository.
+
+        Parameters
+        ----------
+        str : string
+            A string containing a datetime object representing the datetime of
+            the last commit to the repo
+        """
+        url = repo + "/commits"
+        response = requests.get(
+            url, headers={"Authorization": f"token {self.get_token()}"}
+        ).json()
+        date = response[0]["commit"]["author"]["date"]
+
+        return date

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -25,12 +25,8 @@ class ProcessIssues:
         github_api : str
             Instantiated instance of a GitHubAPI object
         """
-        # self.org: str = org
-        # self.repo_name: str = repo_name
-        # self.label_name: str = label_name
-        # self.contrib_instance = ProcessContributors([])
+
         self.github_api = github_api
-        # self.GITHUB_TOKEN = self.contrib_instance.get_token()
 
     # These are the github metrics to return on a package
     # It could be simpler to implement this using graphQL
@@ -44,34 +40,6 @@ class ProcessIssues:
         "open_issues_count",
         "forks_count",
     ]
-
-    # @property
-    # def api_endpoint(self):
-    #     url = (
-    #         f"https://api.github.com/repos/{self.org}/{self.repo_name}/"
-    #         f"issues?labels={self.label_name}&state=all&per_page=100"
-    #     )
-    #     return url
-
-    # # Set up the API endpoint
-    # def _get_response(self):
-    #     """
-    #     # Make a GET request to the API endpoint
-    #     """
-
-    #     print(self.api_endpoint)
-
-    #     try:
-    #         response = requests.get(
-    #             self.api_endpoint,
-    #             headers={"Authorization": f"token {self.GITHUB_TOKEN}"},
-    #         )
-    #         response.raise_for_status()
-
-    #     except requests.HTTPError as exception:
-    #         raise exception
-
-    #     return response
 
     def return_response(self) -> list[dict[str, object]]:
         """
@@ -110,9 +78,6 @@ class ProcessIssues:
         """Parses through each header comment for selected reviews and returns
         review metadata.
 
-        Returns:
-        GitHub Issue meta: "created_at", "updated_at", "closed_at"
-
         Parameters
         ----------
         issues : list
@@ -127,7 +92,7 @@ class ProcessIssues:
         Dict
             A dictionary containing metadata for the issue including the
             package name, description, review team, version submitted etc.
-            See key_order below for the full list of keys.
+            See meta_dates below for the full list of keys.
         """
 
         meta_dates = ["created_at", "updated_at", "closed_at"]
@@ -363,7 +328,7 @@ class ProcessIssues:
 
         return clean_markdown(pkg_name), body_data
 
-    # TODO: This is also github related rename get_repo_metrics
+    # Rename to process_gh_metrics?
     def get_gh_metrics(
         self,
         endpoints: dict[str, str],
@@ -402,48 +367,43 @@ class ProcessIssues:
         return reviews
 
     # This is also github related
-    def process_repo_meta(self, url: str) -> dict:
+    def process_repo_meta(self, url: str) -> dict[str, Any]:
         """
-        Make a get call which returns metadata from the GitHub API about
-        a single repository. Create a dictionary containing all of the
-        specified github metrics for that repository that we want to use.
+        Process metadata from the GitHub API about a single repository.
 
+        Parameters
+        ----------
+        url : str
+            The URL of the repository.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing the specified GitHub metrics for the repo.
+
+        Notes
+        -----
+        This method uses our github module to process returned data from a
+        GET call to the GitHub API to retrieve metadata about a package
+        repository. It then extracts the desired metrics from the API response
+        and constructs a dictionary with these metrics.
+
+        The `homepage` metric is renamed to `documentation` in the returned
+        dictionary.
 
         """
-        # Extract the description and homepage URL from the response JSON
 
         stats_dict = {}
         # Returns the raw top-level github API response for the repo
         gh_repo_response = self.github_api.get_repo_meta(url)
 
         # Retrieve the metrics that we want to track
-
         for astat in self.gh_stats:
             stats_dict[astat] = gh_repo_response[astat]
 
         stats_dict["documentation"] = stats_dict.pop("homepage")
 
         return stats_dict
-
-    # def return_repo_contribs(self, url: str) -> int:
-    #     """
-    #     Returns the number of contributors to a specific repo.
-
-    #     """
-
-    #     return self.github_api.get_repo_contribs(url)
-
-    # def get_last_commit(self, repo: str) -> str:
-    #     """Returns the last commit to the repository.
-
-    #     Parameters
-    #     ----------
-    #     str : string
-    #         A string containing a datetime object representing the datetime of
-    #         the last commit to the repo
-    #     """
-
-    #     return self.github_api.get_last_commit(repo)
 
     # This works - i could just make it more generic and remove fmt since it's
     # not used and replace it with a number of values and a test string

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
 import pytest
 
+from pyosmeta.github_api import GitHubAPI
 from pyosmeta.parse_issues import ProcessIssues
 
 
 @pytest.fixture
 def process_issues():
     """A fixture that returns an instance of the ProcessIssues class"""
-    process_issues = ProcessIssues(
-        repo_name="pyostest", org="pyopensci", label_name="test"
-    )
+    gh_client = GitHubAPI()
+    process_issues = ProcessIssues(gh_client)
     return process_issues
 
 

--- a/tests/unit/test_github_api.py
+++ b/tests/unit/test_github_api.py
@@ -33,13 +33,10 @@ def test_get_token(mock_github_token):
     assert token == os.environ["GITHUB_TOKEN"]
 
 
-# This test should work but it keeps finding my local envt var
-# Even tho i'm removing it in the monkey patch and using a temp
-# Directory
-# def test_missing_token(mock_missing_github_token, tmpdir):
-#     """Test that a keyerror is raised when the token is missing."""
-#     os.chdir(tmpdir)
-#     github_api = GitHubAPI()
+def test_missing_token(mock_missing_github_token, tmpdir):
+    """Test that a keyerror is raised when the token is missing."""
+    os.chdir(tmpdir)
+    github_api = GitHubAPI()
 
-#     with pytest.raises(KeyError, match="Oops! A GITHUB_TOKEN environment"):
-#         github_api.get_token()
+    with pytest.raises(KeyError, match="Oops! A GITHUB_TOKEN environment"):
+        github_api.get_token()

--- a/tests/unit/test_github_api.py
+++ b/tests/unit/test_github_api.py
@@ -1,0 +1,45 @@
+import os
+
+import pytest
+import secrets
+
+from pyosmeta.github_api import GitHubAPI
+
+
+@pytest.fixture
+def mock_github_token(monkeypatch):
+    """Fixture to create a mock token - i don't believe this
+    is working as expected either."""
+    # Generate a random token
+    random_token = secrets.token_hex(16)
+
+    # Mocking the GitHub token in the environment variable
+    monkeypatch.setenv("GITHUB_TOKEN", random_token)
+
+
+@pytest.fixture
+def mock_missing_github_token(monkeypatch, tmpdir):
+    os.chdir(tmpdir)
+    # Remove the GitHub token from the environment variable
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+
+def test_get_token(mock_github_token):
+    """Test that get_token accesses the token correctly when it is
+    present."""
+    github_api = GitHubAPI()
+    token = github_api.get_token()
+
+    assert token == os.environ["GITHUB_TOKEN"]
+
+
+# This test should work but it keeps finding my local envt var
+# Even tho i'm removing it in the monkey patch and using a temp
+# Directory
+# def test_missing_token(mock_missing_github_token, tmpdir):
+#     """Test that a keyerror is raised when the token is missing."""
+#     os.chdir(tmpdir)
+#     github_api = GitHubAPI()
+
+#     with pytest.raises(KeyError, match="Oops! A GITHUB_TOKEN environment"):
+#         github_api.get_token()

--- a/tests/unit/test_parse_categories.py
+++ b/tests/unit/test_parse_categories.py
@@ -1,7 +1,6 @@
 import pytest
 
 from pyosmeta.models import ReviewModel
-from pyosmeta.parse_issues import ProcessIssues
 
 checked = [
     ["Submitting Author", "Nabil Freij (@nabobalis)"],
@@ -52,17 +51,13 @@ no_categories = [
     ],
 )
 def test_get_categories(
-    issue_list: list[list[str]], expected_categories: list[str | None]
+    issue_list: list[list[str]],
+    expected_categories: list[str | None],
+    process_issues,
 ):
-    # Initialize your class or use an existing instance
-    issues = ProcessIssues(
-        org="pyopensci",
-        repo_name="software-submission",
-        label_name="presubmission",
-    )
 
     # Call the get_categories method
-    categories = issues.get_categories(issue_list, "## Scope", 3)
+    categories = process_issues.get_categories(issue_list, "## Scope", 3)
 
     # Assert the result matches the expected categories
     assert categories == expected_categories


### PR DESCRIPTION
this is the first part of addressing #125 

it moves all of the gh methods from parse issues into a new module. 
tests are still needed so opening as a draft. 