### PR TITLE
Fix: add partners to contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix: Add tests for all utils functions (@lwasser, #122)
 - Fix: Bug where date_accepted is removed (@lwasser, #129)
 - Fix: Refactor all GitHub related methods move to gh_client module (@lwasser, #125)
+- Add: support for partners and emeritus_editor in contributor model (@lwasser, #133)
 
 
 ## [v0.2.3] - 2024-02-29

--- a/src/pyosmeta/cli/update_contributors.py
+++ b/src/pyosmeta/cli/update_contributors.py
@@ -35,7 +35,7 @@ def main():
         "software-peer-review",
         "pyopensci.github.io",
         "software-review",
-        "update-web-metadata",
+        "pyosmeta",
     ]
     json_files = create_paths(repos)
 
@@ -51,6 +51,8 @@ def main():
     all_contribs = {}
     for a_contrib in web_contribs:
         print(a_contrib["github_username"])
+        if a_contrib["github_username"] == "hamogu":
+            print("moritz")
         try:
             all_contribs[a_contrib["github_username"].lower()] = PersonModel(
                 **a_contrib

--- a/src/pyosmeta/cli/update_contributors.py
+++ b/src/pyosmeta/cli/update_contributors.py
@@ -51,8 +51,6 @@ def main():
     all_contribs = {}
     for a_contrib in web_contribs:
         print(a_contrib["github_username"])
-        if a_contrib["github_username"] == "hamogu":
-            print("moritz")
         try:
             all_contribs[a_contrib["github_username"].lower()] = PersonModel(
                 **a_contrib

--- a/src/pyosmeta/models.py
+++ b/src/pyosmeta/models.py
@@ -96,6 +96,9 @@ class PersonModel(BaseModel, UrlValidatorMixin):
     editorial_board: Optional[bool] = Field(
         None, validation_alias=AliasChoices("editorial-board")
     )
+    emeritus_editor: Optional[bool] = Field(
+        None, validation_alias=AliasChoices("emeritus_editor")
+    )
     advisory: Optional[bool] = False
     twitter: Optional[str] = Field(
         None, validation_alias=AliasChoices("twitter_username")
@@ -104,6 +107,7 @@ class PersonModel(BaseModel, UrlValidatorMixin):
         None, validation_alias=AliasChoices("mastodon_username", "mastodon")
     )
     orcidid: Optional[str] = None
+    partners: Optional[list[str]] = None
     website: Optional[str] = Field(
         None, validation_alias=AliasChoices("blog", "website")
     )
@@ -124,6 +128,8 @@ class PersonModel(BaseModel, UrlValidatorMixin):
     )
     @classmethod
     def convert_to_set(cls, value: list[str]):
+        """This method converts any list of things ingested into the
+        model into a set object for cleaner parsing"""
         if isinstance(value, list):
             if not value:
                 return set()


### PR DESCRIPTION
closes #133 

This is the last step (i think) in our partner process workflow update. It adds a partners field to the contributor model as format list. it also adds support for the emeritus_editor field so we can acknowledge all past editors. 