### PR TITLE
Sign pypi releases using sigstore

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -70,3 +70,38 @@ jobs:
         # Only publish to real PyPI on release
         if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
+  sign-files:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    if: github.repository_owner == 'pyopensci'
+    needs:
+    - publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # this permission is mandatory for modifying GitHub Releases
+      id-token: write  # this permission is mandatory for sigstore
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Upload artifact signatures to GitHub Release
+      # Only upload on release
+      if: github.event_name == 'release'
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
       - id: isort
         files: \.py$
         args: ["--profile", "black", --line-length=79]
+
+  # Ensure GitHub workflows match the expected schema.
+  - repo: https://github.com/sirosen/check-jsonschema
+    rev: 0.28.3
+    hooks:
+      - id: check-github-workflows


### PR DESCRIPTION
Fixes #146 

Uses the example given at [packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#signing-the-distribution-packages](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#signing-the-distribution-packages).

I adapted it for the use case of this repository.  The major difference in workflow is that this repository starts the release process by creating a GitHub Release, while the referenced example creates the GitHub Release as part of the workflow.

The new job runs after the `publish` step has completed, to ensure that the files have been correctly uploaded to PyPI.  It is run in a dedicated `signature` environment, so that it can have its own set of environment permissions and secrets, if desired.  The job is only run against the source repository, not on forks.

The job downloads the distribution files that were created in the `build` job, and then uses the `sigstore/gh-action-sigstore-python` action to create signature files for the distribution files.  This action requires on a GitHub-provided OIDC token, which is why the job has `id-token: write` permissions.

Finally, the job uploads the distribution and signature files to GitHub Release that triggered the workflow.    This is only done if the workflow was trigged by a release event.   This action requires `contents:write` permission to be able to upload the files to the GitHub release.

--- 

I also added a new pre-commit hook that validates GitHub workflows against the published JSON schema.