### PR TITLE
Fix sigstore job

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -84,7 +84,7 @@ jobs:
       id-token: write  # this permission is mandatory for sigstore
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
Addresses failure seen in https://github.com/pyOpenSci/pyosMeta/actions/runs/9765882417/job/26957638716, "Unable to find any artifacts for the associated workflow".  We need to use consistent versions of the upload and download actions.