### PR TITLE
fix parsing of partnerships

### DIFF
--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -20,6 +20,7 @@ from pydantic import (
 
 from pyosmeta.utils_clean import clean_date, clean_markdown
 
+
 class Partnerships(str, Enum):
     astropy = 'astropy'
     pangeo = 'pangeo'

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -22,8 +22,9 @@ from pyosmeta.utils_clean import clean_date, clean_markdown
 
 
 class Partnerships(str, Enum):
-    astropy = 'astropy'
-    pangeo = 'pangeo'
+    astropy = "astropy"
+    pangeo = "pangeo"
+
 
 class UrlValidatorMixin:
     """A mixin to validate classes that are of the same type across

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -5,6 +5,7 @@ This module also includes a convenience class for URL validation.
 
 import re
 from datetime import datetime
+from enum import Enum
 from typing import Any, Optional, Set, Union
 
 import requests
@@ -19,6 +20,9 @@ from pydantic import (
 
 from pyosmeta.utils_clean import clean_date, clean_markdown
 
+class Partnerships(str, Enum):
+    astropy = 'astropy'
+    pangeo = 'pangeo'
 
 class UrlValidatorMixin:
     """A mixin to validate classes that are of the same type across
@@ -227,6 +231,7 @@ class ReviewModel(BaseModel):
         populate_by_name=True,
         str_strip_whitespace=True,
         validate_assignment=True,
+        use_enum_values=True,
     )
 
     package_name: str | None = ""
@@ -252,7 +257,7 @@ class ReviewModel(BaseModel):
     closed_at: Optional[datetime] = None
     issue_link: str = None
     joss: Optional[str] = None
-    partners: Optional[list[str]] = None
+    partners: Optional[list[Partnerships]] = None
     gh_meta: Optional[GhMeta] = None
 
     @field_validator(

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -13,7 +13,7 @@ from .github_api import GitHubAPI
 from .utils_clean import clean_date_accepted_key
 from .utils_parse import parse_user_names
 
-KEYED_STRING = re.compile(r'\s*(?P<key>\w*?)\s*:\s*(?P<value>.*)')
+KEYED_STRING = re.compile(r'\s*(?P<key>\S*?)\s*:\s*(?P<value>.*)\s*')
 """
 Parse a key-value string into keys and values.
 

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -491,6 +491,10 @@ class ProcessIssues:
         ]
         categories = [item.lower().replace("[^1]", "") for item in categories]
         if keyed:
-            categories = [KEYED_STRING.search(c).groupdict().get('key') for c in categories]
+            categories = [
+                KEYED_STRING.search(c).groupdict().get('key')
+                for c in categories
+                if KEYED_STRING.search(c) is not None
+            ]
 
         return categories

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -13,7 +13,7 @@ from .github_api import GitHubAPI
 from .utils_clean import clean_date_accepted_key
 from .utils_parse import parse_user_names
 
-KEYED_STRING = re.compile(r'\s*(?P<key>\S*?)\s*:\s*(?P<value>.*)\s*')
+KEYED_STRING = re.compile(r"\s*(?P<key>\S*?)\s*:\s*(?P<value>.*)\s*")
 """
 Parse a key-value string into keys and values.
 
@@ -23,6 +23,7 @@ Examples:
     >>> KEYED_STRING.search(text).groupdict()
     {'key': 'Astropy', 'value': 'Link coming soon to standards'}
 """
+
 
 @dataclass
 class ProcessIssues:
@@ -432,7 +433,11 @@ class ProcessIssues:
     # This works - i could just make it more generic and remove fmt since it's
     # not used and replace it with a number of values and a test string
     def get_categories(
-        self, issue_list: list[str], section_str: str, num_vals: int, keyed:bool=False
+        self,
+        issue_list: list[str],
+        section_str: str,
+        num_vals: int,
+        keyed: bool = False,
     ) -> list[str] | None:
         """Parse through a pyOS review issue and grab categories associated
         with a package
@@ -492,7 +497,7 @@ class ProcessIssues:
         categories = [item.lower().replace("[^1]", "") for item in categories]
         if keyed:
             categories = [
-                KEYED_STRING.search(c).groupdict().get('key')
+                KEYED_STRING.search(c).groupdict().get("key")
                 for c in categories
                 if KEYED_STRING.search(c) is not None
             ]

--- a/tests/data/reviews/partnership_astropy.txt
+++ b/tests/data/reviews/partnership_astropy.txt
@@ -1,0 +1,58 @@
+Submitting Author: Author Name (@username)
+All current maintainers: (@username, @username2)
+Package Name: PackageName
+One-Line Description of Package: Package description
+Repository Link:  https://example.com/username/repository
+Version submitted:  v.0.8.5
+Editor: @editoruser
+Reviewer 1: @reviewer1
+Reviewer 2: @reviewer2
+Archive: [![DOI](https://zenodo.org/badge/DOI/fakedoi/doi.svg)](https://doi.org/fakedoi/doi.svg)
+JOSS DOI: [![DOI](https://joss.theoj.org/papers/fakedoi.svg)](https://joss.theoj.org/papers/fakedoi)
+Version accepted: v.0.9.2
+Date accepted (month/day/year): 04/21/2024
+
+---
+
+## Code of Conduct & Commitment to Maintain Package
+
+- [x] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in maintaining my package after should it be accepted.
+- [x] I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines][Commitment].
+
+## Description
+
+Description of package
+
+That spans multiple lines
+
+## Scope
+
+- Please indicate which category or categories.
+Check out our [package scope page][PackageCategories] to learn more about our
+scope. (If you are unsure of which category you fit, we suggest you make a pre-submission inquiry):
+
+	- [ ] Data retrieval
+	- [ ] Data extraction
+	- [ ] Data processing/munging
+	- [ ] Data deposition
+	- [ ] Data validation and testing
+	- [ ] Data visualization[^1]
+	- [ ] Workflow automation
+	- [ ] Citation management and bibliometrics
+	- [x] Scientific software wrappers
+	- [ ] Database interoperability
+
+ZodiPy was already [proposed and reviewed as an Astropy Affiliated package](https://github.com/astropy/astropy.github.com/pull/495) before the recent partnership between Astropy and pyOpenSci in [APE22](https://github.com/astropy/astropy-APEs/blob/main/APE22.rst#in-a-nutshell), so I am resubmitting the proposal as is here.
+
+## Domain Specific
+
+- [ ] Geospatial
+- [ ] Education
+
+## Community Partnerships
+If your package is associated with an
+existing community please check below:
+
+- [x] Astropy: Link coming soon to standards
+- [ ] Pangeo: My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook][PangeoCollaboration]
+

--- a/tests/data/reviews/partnership_astropy.txt
+++ b/tests/data/reviews/partnership_astropy.txt
@@ -55,4 +55,3 @@ existing community please check below:
 
 - [x] Astropy: Link coming soon to standards
 - [ ] Pangeo: My package adheres to the [Pangeo standards listed in the pyOpenSci peer review guidebook][PangeoCollaboration]
-

--- a/tests/unit/test_parse_categories.py
+++ b/tests/unit/test_parse_categories.py
@@ -97,11 +97,9 @@ def test_clean_categories(
     review = ReviewModel.clean_categories(categories=input_categories)
     assert review == expected_return
 
+
 @pytest.mark.parametrize(
-    'partners,input_file',
-    [
-        (['astropy'], 'reviews/partnership_astropy.txt')
-    ]
+    "partners,input_file", [(["astropy"], "reviews/partnership_astropy.txt")]
 )
 def test_parse_partnerships(partners, input_file, data_file, process_issues):
     """

--- a/tests/unit/test_parse_categories.py
+++ b/tests/unit/test_parse_categories.py
@@ -96,3 +96,18 @@ def test_clean_categories(
 
     review = ReviewModel.clean_categories(categories=input_categories)
     assert review == expected_return
+
+@pytest.mark.parametrize(
+    'partners,input_file',
+    [
+        (['astropy'], 'reviews/partnership_astropy.txt')
+    ]
+)
+def test_parse_partnerships(partners, input_file, data_file, process_issues):
+    """
+    The community partnership checkboxes should be correctly parsed into
+    a value in the :class:`.Partnerships` enum
+    """
+    review = data_file(input_file, True)
+    review = process_issues.parse_issue(review)
+    assert review.partners == partners

--- a/tests/unit/test_parse_issue_header_methods.py
+++ b/tests/unit/test_parse_issue_header_methods.py
@@ -2,6 +2,9 @@
 This workflow grabs the first comment from the review header and
 parses out (and cleans) pyOpenSci review metadata.
 """
+import pytest
+
+from pyosmeta.parse_issues import KEYED_STRING
 
 
 def test_issue_as_dict(process_issues, issue_list):
@@ -14,3 +17,34 @@ def test_issue_as_dict(process_issues, issue_list):
     meta = process_issues._header_as_dict(header)
     assert meta["package_name"] == "sunpy"
     assert len(meta) == 13
+
+
+@pytest.mark.parametrize(
+    'text,expected',
+    [
+        pytest.param('apple: banana', {'key': 'apple', 'value': 'banana'},id='base'),
+        pytest.param('Apple :  Banana', {'key': 'Apple', 'value': 'Banana'}, id='whitespace'),
+        pytest.param(' Apple : Banana ',  {'key': 'Apple', 'value': 'Banana '}, id='whitespace-leading'),
+        pytest.param('Apple: Multiple words', {'key': 'Apple', 'value': 'Multiple words'}, id='whitespace-value'),
+        pytest.param('Apple:banana:cherry', {'key': 'Apple', 'value':'banana:cherry'}, id='non-greedy-key'),
+        pytest.param('a line\nApple: banana cherry\nwatermelon', {'key': 'Apple','value': 'banana cherry'}, id='multiline'),
+        pytest.param('multiword key: banana', {'key': 'key', 'value': 'banana'}, id='multiword-key'),
+        pytest.param('multiword-key: banana', {'key': 'multiword-key', 'value': 'banana'}, id='multiword-key-hyphenated'),
+        pytest.param('* bulleted: key', {'key': 'bulleted', 'value': 'key'}, id='bulleted-key'),
+
+    ]
+)
+def test_keyed_string(text, expected):
+    """
+    KEYED_STRING can parse a key: value pair from a string as regex results dict.
+
+    This is super general - we want to get any key/value-ish pair whether it's right or wrong,
+    we don't want to try and squeeze all normalization and cleaning into a single re, so it
+    eg. doesn't strip trailing whitespace and detects mid-line keys: like that
+    """
+    matched = KEYED_STRING.search(text).groupdict()
+    if expected:
+        assert matched == expected
+    else:
+        assert matched is None
+

--- a/tests/unit/test_parse_issue_header_methods.py
+++ b/tests/unit/test_parse_issue_header_methods.py
@@ -3,7 +3,6 @@ This workflow grabs the first comment from the review header and
 parses out (and cleans) pyOpenSci review metadata.
 """
 import pytest
-
 from pyosmeta.parse_issues import KEYED_STRING
 
 

--- a/tests/unit/test_parse_issue_header_methods.py
+++ b/tests/unit/test_parse_issue_header_methods.py
@@ -2,6 +2,7 @@
 This workflow grabs the first comment from the review header and
 parses out (and cleans) pyOpenSci review metadata.
 """
+
 import pytest
 from pyosmeta.parse_issues import KEYED_STRING
 
@@ -19,19 +20,52 @@ def test_issue_as_dict(process_issues, issue_list):
 
 
 @pytest.mark.parametrize(
-    'text,expected',
+    "text,expected",
     [
-        pytest.param('apple: banana', {'key': 'apple', 'value': 'banana'},id='base'),
-        pytest.param('Apple :  Banana', {'key': 'Apple', 'value': 'Banana'}, id='whitespace'),
-        pytest.param(' Apple : Banana ',  {'key': 'Apple', 'value': 'Banana '}, id='whitespace-leading'),
-        pytest.param('Apple: Multiple words', {'key': 'Apple', 'value': 'Multiple words'}, id='whitespace-value'),
-        pytest.param('Apple:banana:cherry', {'key': 'Apple', 'value':'banana:cherry'}, id='non-greedy-key'),
-        pytest.param('a line\nApple: banana cherry\nwatermelon', {'key': 'Apple','value': 'banana cherry'}, id='multiline'),
-        pytest.param('multiword key: banana', {'key': 'key', 'value': 'banana'}, id='multiword-key'),
-        pytest.param('multiword-key: banana', {'key': 'multiword-key', 'value': 'banana'}, id='multiword-key-hyphenated'),
-        pytest.param('* bulleted: key', {'key': 'bulleted', 'value': 'key'}, id='bulleted-key'),
-
-    ]
+        pytest.param(
+            "apple: banana", {"key": "apple", "value": "banana"}, id="base"
+        ),
+        pytest.param(
+            "Apple :  Banana",
+            {"key": "Apple", "value": "Banana"},
+            id="whitespace",
+        ),
+        pytest.param(
+            " Apple : Banana ",
+            {"key": "Apple", "value": "Banana "},
+            id="whitespace-leading",
+        ),
+        pytest.param(
+            "Apple: Multiple words",
+            {"key": "Apple", "value": "Multiple words"},
+            id="whitespace-value",
+        ),
+        pytest.param(
+            "Apple:banana:cherry",
+            {"key": "Apple", "value": "banana:cherry"},
+            id="non-greedy-key",
+        ),
+        pytest.param(
+            "a line\nApple: banana cherry\nwatermelon",
+            {"key": "Apple", "value": "banana cherry"},
+            id="multiline",
+        ),
+        pytest.param(
+            "multiword key: banana",
+            {"key": "key", "value": "banana"},
+            id="multiword-key",
+        ),
+        pytest.param(
+            "multiword-key: banana",
+            {"key": "multiword-key", "value": "banana"},
+            id="multiword-key-hyphenated",
+        ),
+        pytest.param(
+            "* bulleted: key",
+            {"key": "bulleted", "value": "key"},
+            id="bulleted-key",
+        ),
+    ],
 )
 def test_keyed_string(text, expected):
     """
@@ -46,4 +80,3 @@ def test_keyed_string(text, expected):
         assert matched == expected
     else:
         assert matched is None
-


### PR DESCRIPTION
Fix: https://github.com/pyOpenSci/pyosMeta/issues/186

sorry this is coming so late today, i have been helping everyone else will stuff all day long and haven't even gotten to any of my own work yet lmao, but since i caused this bug i wanted to fix ASAP.

so here's fix as discussed 
- **model** - used  string enum (python 3.10 doesn't have `enum.StrEnum`) instead of a `Literal` because in the future it would be nice to be able to add annotations like the text that comes after the key in the template currently so that we can generate the review template directly from the model. It does the same thing - the pydantic model will validate and throw an error there if there's any value that isn't in that enum. 
- **get_categories** - since the same method `get_categories` is used for parsing a regular checklist and a checklist that is effectively a key: value pair, i added a `keyed` param that extracts the key. 
- **test, regex** - to do that, i made a regex pattern and added tests for that so at least i have declared the expected behavior of that pattern lol
- **test, parsing** - also added a fake review based on a real one to test actual parsing of an actual issue

so by making the model more strict we now can make the claim that "this key will always be this value or absent" and "if the string is within the tested boundaries of the regex pattern it will be present." We need to do that for the rest of the model now too - make it reflect the contract we want to make with anyone ingesting data from our packages.yaml file: eg. currently `package_name` is optional and defaults to a blank string, but we should actually never have a review with no package name. and so on.  but that's enough for this v simple lil bug
