### PR TITLE
get labels from issue metadata

### DIFF
--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -18,6 +18,7 @@ from pydantic import (
 )
 
 from pyosmeta.utils_clean import clean_date, clean_markdown
+from pyosmeta.models.github import Labels
 
 
 class UrlValidatorMixin:
@@ -254,6 +255,7 @@ class ReviewModel(BaseModel):
     joss: Optional[str] = None
     partners: Optional[list[str]] = None
     gh_meta: Optional[GhMeta] = None
+    labels: list[str] = Field(default_factory=list)
 
     @field_validator(
         "date_accepted",
@@ -368,3 +370,13 @@ class ReviewModel(BaseModel):
             return [item]
         else:
             return item
+
+    @field_validator("labels", mode="before")
+    def extract_label(cls, labels: list[str | Labels]) -> list[str]:
+        """
+        Get just the ``name`` from the Labels model, if given
+        """
+        return [
+            label.name if isinstance(label, Labels) else label
+            for label in labels
+        ]

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -17,8 +17,8 @@ from pydantic import (
     field_validator,
 )
 
-from pyosmeta.utils_clean import clean_date, clean_markdown
 from pyosmeta.models.github import Labels
+from pyosmeta.utils_clean import clean_date, clean_markdown
 
 
 class UrlValidatorMixin:

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -245,6 +245,7 @@ class ProcessIssues:
                     "updated_at",
                     "closed_at",
                     "repository_url",
+                    "labels",
                 ],
             )
 

--- a/tests/integration/test_parse_issues.py
+++ b/tests/integration/test_parse_issues.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pyosmeta.models import ReviewUser
+from pyosmeta.models.github import Labels
 
 
 def test_parse_issue_header(process_issues, issue_list):
@@ -47,3 +48,23 @@ def test_parse_bolded_keys(process_issues, data_file):
     review = data_file("reviews/bolded_keys.txt", True)
     review = process_issues.parse_issue(review)
     assert review.package_name == "fake_package"
+
+
+def test_parse_labels(issue_list, process_issues):
+    """
+    `Label` models should be coerced to a string when parsing an issue
+    """
+    label_inst = Labels(
+        id=1196238794,
+        node_id="MDU6TGFiZWwxMTk2MjM4Nzk0",
+        url="https://api.github.com/repos/pyOpenSci/software-submission/labels/6/pyOS-approved",
+        name="6/pyOS-approved",
+        description="",
+        color="006B75",
+        default=False,
+    )
+    labels = [label_inst, "another_label"]
+    for issue in issue_list:
+        issue.labels = labels
+        review = process_issues.parse_issue(issue)
+        assert review.labels == ["6/pyOS-approved", "another_label"]


### PR DESCRIPTION
Fix: https://github.com/pyOpenSci/pyosMeta/issues/188

sorta self explanatory, we can keep the whole `Issue` object if we want, i just figure we sorta want to keep the review `yaml` tidy-ish and wasn't sure if we would want to use any of those other fields. if we want it it would just be a matter of removing the validator and changing the field type.