### PR TITLE
Fix: fix label parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+* Fix: allow for issues with multiple labels & fix presubmission ingest (@lwasser)
+
 ## [v0.3.2] - 2024-07-04
 
 ### Fixes

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -73,12 +73,34 @@ class GitHubAPI:
             )
 
     @property
-    def api_endpoint(self):
-        labels_query = ",".join(self.labels) if self.labels else ""
-        url = (
-            f"https://api.github.com/repos/{self.org}/{self.repo}/"
-            f"issues?labels={labels_query}&state=all&per_page=100"
-        )
+    def api_endpoint(self) -> str:
+        """Create the API endpoint url
+
+        Returns
+        -------
+        str
+            A string representing the api endpoint to query.
+
+        Notes
+        -----
+        The rest API will look for issues that have ALL labels provided in a
+        query (using an AND query vs an OR query by default). The graphQL may
+        support OR. As such if there is a list provided, we will want to parse
+        down the returned list to only include issues with a specific label
+        included.
+        """
+        # If there is more than one label provided, request all issues
+        # Will have to parse later.
+        if len(self.labels) > 1:
+            url = (
+                f"https://api.github.com/repos/{self.org}/{self.repo}/"
+                f"issues?state=all&per_page=100"
+            )
+        else:
+            url = (
+                f"https://api.github.com/repos/{self.org}/{self.repo}/"
+                f"issues?labels={self.labels[0]}&state=all&per_page=100"
+            )
         return url
 
     def handle_rate_limit(self, response):

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -243,7 +243,8 @@ class ReviewModel(BaseModel):
     )
     submitting_author: ReviewUser | None = None
     all_current_maintainers: list[ReviewUser] = Field(default_factory=list)
-    repository_link: str
+    # Support presubmissions with an alias
+    repository_link: str = Field(..., alias="repository_link_(if_existing)")
     version_submitted: Optional[str] = None
     categories: Optional[list[str]] = None
     editor: ReviewUser | None = None

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -67,10 +67,25 @@ class ProcessIssues:
         -------
         list
             List of dict items each containing a review issue
+
+        Notes
+        -----
+        We add a filter here to labels because the github api defaults to
+        grabbing issues with ALL using an and operator labels in a list. We
+        need to use an OR as a selector.
         """
 
         issues = self.github_api.return_response()
-        return [Issue(**i) for i in issues]
+        # Filter labels according to label select input
+        labels = self.github_api.labels
+
+        filtered_issues = [
+            issue
+            for issue in issues
+            if any(label["name"] in labels for label in issue["labels"])
+        ]
+
+        return [Issue(**i) for i in filtered_issues]
 
     def _is_review_role(self, string: str) -> bool:
         """


### PR DESCRIPTION
closes #192 

Right now i was trying to pull all issues which meant it was grabbing issues that were NOT actually review issues. I decided it was better to be explicit. This pr thus fixes two things

1. it allows us to parse through issues and look for issues that contain a specific label. By default the rest endpoint returns issues with ALL labels included. But we wanted the select an issue based upon a specific label occuring within a set of labels. This implements that by filtering issues. GraphQL i think has an OR option? but i just am trying to get the peer-review-metrics running again with this pr. 
2. This pr also adds an alias for repo_link to support the presubmission template