### PR TITLE
Relax codecov settings in CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+# Set non-blocking status checks
+coverage:
+  status:
+    project:
+      default:
+        # Allows 10% drop from previous base commit
+        threshold: 10%
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
           update-reviews
           update-review-teams
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.2
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
This PR relaxes errors in CI for codecov. It also updates the version on the GitHub action to allow for dot-release updates of the action itself.