### PR TITLE
Add: additional repos to parse contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+* Add: pyos Repos that contributors contribute to  (@lwasser, #197)
+
 ## [v0.3.5] - 2024-08-15
 
 This is a tiny release to add support for pr and issue aggregation in our metrics.
@@ -11,6 +13,7 @@ This is a tiny release to add support for pr and issue aggregation in our metric
 ### Add
 
 * Add: Endpoint variable to support both prs and issues to GitHubAPI (@lwasser)
+* Add: Tests for the contributors module & file_io (@willingc)
 
 ## [v0.3.4] - 2024-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [v0.3.6] - 2024-08-15
+
 * Add: pyos Repos that contributors contribute to  (@lwasser, #197)
 
 ## [v0.3.5] - 2024-08-15

--- a/src/pyosmeta/cli/update_contributors.py
+++ b/src/pyosmeta/cli/update_contributors.py
@@ -8,10 +8,6 @@ from pyosmeta.file_io import create_paths, load_pickle, open_yml_file
 from pyosmeta.github_api import GitHubAPI
 from pyosmeta.models import PersonModel
 
-# TODO - https://stackoverflow.com
-# /questions/55762673/how-to-parse-list-of-models-with-pydantic
-# I can use TypeAdapter to convert the json data to model objects!
-
 
 def main():
     update_dates = False
@@ -36,6 +32,11 @@ def main():
         "pyopensci.github.io",
         "software-review",
         "pyosmeta",
+        "handbook",
+        "software-submission",
+        "peer-review-metrics",
+        "pyosPackage",
+        "pyos-sphinx-theme",
     ]
     json_files = create_paths(repos)
 


### PR DESCRIPTION
closes #197 

this adds repos others have contributed to. I'm doing this because i want to update our current metrics and they don't currently capture all of the contributions going on in our org because not all of the repos are parsed in the workflow!