### PR TITLE
feat: Add after date to api call 

### DIFF
--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -56,6 +56,7 @@ class GitHubAPI:
         self.labels: list[str] | None = labels
         self.endpoint_type: str = endpoint_type
         # ISO 8601 format YYYY-MM-DDTHH:MM:SSZ.
+        # using the api since query which represents updated at not created_at
         self.after_date: str = after_date
 
     def get_token(self) -> str | None:


### PR DESCRIPTION
This pr adds an optional after_date to the rest call. This will allow us to build a workflow that tracks user contributions over time which is another metrics of pyOS community growth. Prs in particular represent users with some "ownership" and investment in contributing to pyos!