### PR TITLE
fix: make sure eic roles are populated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+* Fix: Eix field not processing correctly  (@lwasser, #234)
 * Fix: Updated documentation throughout with a focus on how a user's name is accessed and updated (@lwasser)
 * Fix: ReviewUser object name can be optional. There are times when we don't have the actual person's name only the GH username (@lwasser)
 

--- a/src/pyosmeta/cli/update_review_teams.py
+++ b/src/pyosmeta/cli/update_review_teams.py
@@ -148,23 +148,28 @@ def main():
         for role in contrib_types.keys():
             user: list[ReviewUser] | ReviewUser = getattr(review, role)
 
-            # Handle lists or single users separately
-            if isinstance(user, list):
-                for i, a_user in enumerate(user):
-                    a_user, contribs = process_user(
-                        a_user, role, pkg_name, contribs, process_contribs
+            # Eic is a newer field, so in some instances it will be empty
+            # if it's empty print a message noting the data are missing
+            if user:
+                # Handle lists or single users separately
+                if isinstance(user, list):
+                    for i, a_user in enumerate(user):
+                        a_user, contribs = process_user(
+                            a_user, role, pkg_name, contribs, process_contribs
+                        )
+                        # Update individual user in reference to issue list
+                        user[i] = a_user
+                elif isinstance(user, ReviewUser):
+                    user, contribs = process_user(
+                        user, role, pkg_name, contribs, process_contribs
                     )
-                    # Update individual user within the user list
-                    user[i] = a_user
-            elif isinstance(user, ReviewUser):
-                user, contribs = process_user(
-                    user, role, pkg_name, contribs, process_contribs
-                )
-                setattr(review, role, user)
+                    setattr(review, role, user)
+                else:
+                    raise TypeError(
+                        "Keys in the `contrib_types` map must be a `ReviewUser` or `list[ReviewUser]` in the `ReviewModel`"
+                    )
             else:
-                raise TypeError(
-                    "Keys in the `contrib_types` map must be a `ReviewUser` or `list[ReviewUser]` in the `ReviewModel`"
-                )
+                print(f"I can't find a username for {role}. Moving on.")
 
     # Export to yaml
     contribs_ls = [model.model_dump() for model in contribs.values()]

--- a/src/pyosmeta/contributors.py
+++ b/src/pyosmeta/contributors.py
@@ -38,7 +38,20 @@ class ProcessContributors:
             "github_username",
         ]
 
+        """A dictionary that maps a category type found in our peer review
+        submission template to the roles and role categories that a contributor
+        should have populated associated with the review in the contributors.yml
+
+        example
+        reviewers is in the software submission template like this:
+        reviewers: @username, @username2
+        Being a reviewer maps to two roles in the users contributions to
+        pyOpenSci: reviewer and peer-review
+        packages_reviewed is another item in the contributors file that lists
+        all of the packages that user has reviewed. So if they ar e
+        """
         self.contrib_types = {
+            "eic": ["packages_eic", ["eic", "peer-review"]],
             "reviewers": ["packages_reviewed", ["reviewer", "peer-review"]],
             "editor": ["packages_editor", ["editor", "peer-review"]],
             "submitting_author": [

--- a/src/pyosmeta/file_io.py
+++ b/src/pyosmeta/file_io.py
@@ -115,8 +115,6 @@ def export_yaml(filename: str, data_list: list):
         yaml.dump(data_list, file)
 
 
-# TODO: Double check - i may be able to combine this with the other clean
-# function created
 def clean_string(astr: str) -> str:
     """
     Clean - remove strings starting with "*id0" and "[]".

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -124,6 +124,7 @@ class PersonModel(BaseModel, UrlValidatorMixin):
     )
     board: Optional[bool] = False
     contributor_type: Set[str] = set()
+    packages_eic: Set[str] = set()
     packages_editor: Set[str] = set()
     packages_submitted: Set[str] = set()
     packages_reviewed: Set[str] = set()
@@ -143,6 +144,7 @@ class PersonModel(BaseModel, UrlValidatorMixin):
         return False
 
     @field_validator(
+        "packages_eic",
         "packages_reviewed",
         "packages_submitted",
         "packages_editor",
@@ -176,6 +178,7 @@ class PersonModel(BaseModel, UrlValidatorMixin):
             raise ValueError(f"{attr_name} is not a set attribute")
 
     @field_serializer(
+        "packages_eic",
         "packages_reviewed",
         "packages_submitted",
         "packages_editor",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ DATA_DIR = Path(__file__).parent / "data"
 
 @pytest.fixture
 def ghuser_response():
-    """This is the initial github response. I changed the username to
+    """This is the initial GitHub response. I changed the username to
     create this object"""
     expected_response = {
         "login": "chayadecacao",

--- a/tests/integration/test_review_model.py
+++ b/tests/integration/test_review_model.py
@@ -1,36 +1,43 @@
+import pytest
+
 from pyosmeta.models import ReviewModel
+
 
 # We could setup some example data using fixtures and a conf.py
 # Once we have a better view of the test suite.
-example = {
-    "submitting_author": {
-        "github_username": "nabobalis",
-        "name": "Nabil Freij",
-    },
-    "all_current_maintainers": [],
-    "package_name": "sunpy",
-    "one-line_description_of_package": "Python for Solar Physics",
-    "repository_link": "https://github.com/sunpy/sunpy",
-    "version_submitted": "5.0.1",
-    "editor": {"github_username": "cmarmo", "name": ""},
-    "reviewer_1": {"github_username": "Septaris", "name": ""},
-    "reviewer_2": {"github_username": "nutjob4life", "name": ""},
-    "archive": "[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8384174.svg)](https://doi.org/10.5281/zenodo.8384174)",
-    "version_accepted": "5.1.1",
-    "joss_doi": "[![DOI](https://joss.theoj.org/papers/10.21105/joss.01832/status.svg)](https://joss.theoj.org/papers/10.21105/joss.01832)",
-    "date_accepted": "01/18/2024",
-    "categories": [
-        "data-retrieval",
-        "data-extraction",
-        "data-processing/munging",
-        "data-visualization",
-    ],
-}
+@pytest.fixture
+def review_data():
+    return {
+        "submitting_author": {
+            "github_username": "nabobalis",
+            "name": "Nabil Freij",
+        },
+        "all_current_maintainers": [],
+        "package_name": "sunpy",
+        "one-line_description_of_package": "Python for Solar Physics",
+        "repository_link": "https://github.com/sunpy/sunpy",
+        "version_submitted": "5.0.1",
+        "eic": {"github_username": "cmarmo", "name": ""},
+        "editor": {"github_username": "cmarmo", "name": ""},
+        "reviewer_1": {"github_username": "Septaris", "name": ""},
+        "reviewer_2": {"github_username": "nutjob4life", "name": ""},
+        "archive": "[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8384174.svg)](https://doi.org/10.5281/zenodo.8384174)",
+        "version_accepted": "5.1.1",
+        "joss_doi": "[![DOI](https://joss.theoj.org/papers/10.21105/joss.01832/status.svg)](https://joss.theoj.org/papers/10.21105/joss.01832)",
+        "date_accepted": "01/18/2024",
+        "categories": [
+            "data-retrieval",
+            "data-extraction",
+            "data-processing/munging",
+            "data-visualization",
+        ],
+    }
 
 
-def test_alias_choices_validation():
+def test_alias_choices_validation(review_data):
     """Test that model correctly recognizes the field alias"""
 
-    new = ReviewModel(**example)
+    new = ReviewModel(**review_data)
     assert new.date_accepted == "2024-01-18"
     assert new.package_description == "Python for Solar Physics"
+    assert new.eic.github_username == "cmarmo"

--- a/tests/unit/test_github_api.py
+++ b/tests/unit/test_github_api.py
@@ -147,21 +147,21 @@ def test_api_endpoint_with_invalid_dates(after_date, expected_url):
 def test_get_user_info_successful(mocker, ghuser_response):
     """Test that an expected response returns properly"""
 
-    expected_response = ghuser_response
     mock_response = mocker.Mock()
     mock_response.status_code = 200
-    mock_response.json.return_value = expected_response
+    mock_response.json.return_value = ghuser_response
     mocker.patch("requests.get", return_value=mock_response)
 
     github_api_instance = GitHubAPI()
     user_info = github_api_instance.get_user_info("example_user")
 
-    assert user_info == expected_response
+    assert user_info == ghuser_response
 
 
 def test_get_user_info_bad_credentials(mocker):
     """Test that a value error is raised when the GH token is not
     valid."""
+
     mock_response = mocker.Mock()
     mock_response.status_code = 401
     mocker.patch("requests.get", return_value=mock_response)

--- a/tests/unit/test_update_review_teams.py
+++ b/tests/unit/test_update_review_teams.py
@@ -1,9 +1,0 @@
-def get_clean_user(username: str) -> str:
-    """A small helper that removes whitespace and ensures username is
-    lower case"""
-    # If the github username has spaces there is an error which might be
-    # that someone added a name after the username. Only return the github
-    # username
-    if len(username.split()) > 1:
-        username = username.split()[0]
-    return username.lower().strip()


### PR DESCRIPTION
This fixes parsing of the EiC role (when it exists) i our review metadata population.
There were a few issues

✅ the field serializer and the validator were not setup to include packages_eic 
✅ eic wasn't a role in our contrib_roles object for the review model so that field wasn't being processed. As such when Chiara added her name which was missing, it was deleted in the next bot update. This is now fixed

This pr doesn't have tests yet but we should add some integration tests that ensure contrib data are processed correctly. and then another test to check serialization to yaml 