### PR TITLE
feat: add archive label and active status to ReviewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Notes: it looks like i may have mistakenly bumped to 1.3.7 in august. rather tha
 ### Added
 
 * Add: new repos to track contribs (@lwasser)
+* Add: new `active` status under `ReviewModel` which is set to `False` if the `"archived"` label is present on a review to mark the package as inactive (@banesullivan)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+* Add: new `active` status under `ReviewModel` which is set to `False` if the `"archived"` label is present on a review to mark the package as inactive (@banesullivan)
+
 [v1.4] - 2024-11-22
 
 Notes: it looks like i may have mistakenly bumped to 1.3.7 in august. rather than try to fix on pypi we will just go with it to ensure our release cycles are smooth given no one else uses this package except pyopensci.
@@ -11,7 +13,6 @@ Notes: it looks like i may have mistakenly bumped to 1.3.7 in august. rather tha
 ### Added
 
 * Add: new repos to track contribs (@lwasser)
-* Add: new `active` status under `ReviewModel` which is set to `False` if the `"archived"` label is present on a review to mark the package as inactive (@banesullivan)
 
 ### Fixed
 

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -279,6 +279,7 @@ class ReviewModel(BaseModel):
     partners: Optional[list[Partnerships]] = None
     gh_meta: Optional[GhMeta] = None
     labels: list[str] = Field(default_factory=list)
+    active: bool = True  # To indicate if package is maintained or archived
 
     @field_validator(
         "date_accepted",

--- a/src/pyosmeta/models/github.py
+++ b/src/pyosmeta/models/github.py
@@ -17,9 +17,10 @@ datamodel-codegen --input issue_schema.json --input-file-type jsonschema --outpu
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 from typing import Any, List, Literal, Optional, Union
 
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, model_validator
 
 
 class User(BaseModel):
@@ -61,6 +62,12 @@ class ClosedBy(User): ...
 class Owner(User): ...
 
 
+class LabelType(str, Enum):
+    ARCHIVED = "archived"
+    PYOS_APPROVED = "6/pyOS-approved"
+    JOSS_APPROVED = "9/joss-approved"
+
+
 class Labels(BaseModel):
     id: Optional[int] = None
     node_id: Optional[str] = None
@@ -69,6 +76,17 @@ class Labels(BaseModel):
     description: Optional[str] = None
     color: Optional[str] = None
     default: Optional[bool] = None
+    type: Optional[LabelType] = None
+
+    @model_validator(mode="before")
+    def parse_label_type(cls, data):
+        """Parse the label type from the name before validation."""
+        if "name" in data:
+            try:
+                data["type"] = LabelType(data["name"])
+            except ValueError:
+                pass
+        return data
 
 
 class Issue(BaseModel):

--- a/src/pyosmeta/models/github.py
+++ b/src/pyosmeta/models/github.py
@@ -77,10 +77,10 @@ class LabelType(str, Enum):
 
 
 class Labels(BaseModel):
+    name: str
     id: Optional[int] = None
     node_id: Optional[str] = None
     url: Optional[AnyUrl] = None
-    name: Optional[str] = None
     description: Optional[str] = None
     color: Optional[str] = None
     default: Optional[bool] = None

--- a/src/pyosmeta/models/github.py
+++ b/src/pyosmeta/models/github.py
@@ -96,11 +96,10 @@ class Labels(BaseModel):
         value to the "archived" label so that we can easily filter out archived
         issues.
         """
-        if "name" in data:
-            try:
-                data["type"] = LabelType(data["name"])
-            except ValueError:
-                pass
+        try:
+            data["type"] = LabelType(data["name"])
+        except ValueError:
+            pass
         return data
 
 

--- a/src/pyosmeta/models/github.py
+++ b/src/pyosmeta/models/github.py
@@ -63,9 +63,17 @@ class Owner(User): ...
 
 
 class LabelType(str, Enum):
+    """Enum for the different types of labels that can be assigned to an issue.
+
+    This enum is not meant to be exhaustive, but rather capture a few important
+    labels for life cycle of approved reviews.
+
+    For now, this only includes the "archived" label, which is used to mark
+    packages that are no longer maintained ("inactive"). The "archived" label
+    corresponds to setting ``active=False`` on the ReviewModel
+    """
+
     ARCHIVED = "archived"
-    PYOS_APPROVED = "6/pyOS-approved"
-    JOSS_APPROVED = "9/joss-approved"
 
 
 class Labels(BaseModel):
@@ -80,7 +88,14 @@ class Labels(BaseModel):
 
     @model_validator(mode="before")
     def parse_label_type(cls, data):
-        """Parse the label type from the name before validation."""
+        """Parse the label type from the name before validation.
+
+        This will parse the label name into an available LabelType enum value.
+        Not all labels will have a corresponding LabelType, so this will
+        gracefully fail. This was implemented for assigning the LabelType.ARCHIVED
+        value to the "archived" label so that we can easily filter out archived
+        issues.
+        """
         if "name" in data:
             try:
                 data["type"] = LabelType(data["name"])

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -233,13 +233,11 @@ class ProcessIssues:
         based on the presence of certain labels in the review issue.
         """
 
-        def _is_archived(label: str) -> bool:
+        def _is_archived(label: str | Labels) -> bool:
             """Internal helper to check if a label is the "archived" label"""
-            if isinstance(label, str):
-                return "archived" in label.lower()
-            elif isinstance(label, Labels):
+            if isinstance(label, Labels):
                 return label.type == LabelType.ARCHIVED
-            raise ValueError("Invalid label type")
+            return "archived" in label.lower()
 
         # Check if the review has the "archived" label
         if "labels" in meta and [

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -223,10 +223,18 @@ class ProcessIssues:
 
     def _postprocess_labels(self, meta: dict) -> dict:
         """
-        Handle specific labels that are model properties
+        Process specific labels for attributes in the review model.
+
+        Presently, this method only checks if the review has the "archived"
+        (LabelType.ARCHIVED) label and sets the active attribute to False
+        if it does. We may add more label processing in the future.
+
+        The intention behind this is to assign specific ReviewModel attributes
+        based on the presence of certain labels in the review issue.
         """
 
         def _is_archived(label: str) -> bool:
+            """Internal helper to check if a label is the "archived" label"""
             if isinstance(label, str):
                 return "archived" in label.lower()
             elif isinstance(label, Labels):

--- a/tests/integration/test_parse_issues.py
+++ b/tests/integration/test_parse_issues.py
@@ -86,3 +86,11 @@ def test_parse_labels(issue_list, process_issues):
         issue.labels = labels
         review = process_issues.parse_issue(issue)
         assert not review.active
+
+    # Handle label with missing details
+    label_inst = Labels(name="test")
+    labels = [label_inst, "another_label"]
+    for issue in issue_list:
+        issue.labels = labels
+        review = process_issues.parse_issue(issue)
+        assert review.labels == ["test", "another_label"]

--- a/tests/integration/test_parse_issues.py
+++ b/tests/integration/test_parse_issues.py
@@ -69,3 +69,20 @@ def test_parse_labels(issue_list, process_issues):
         issue.labels = labels
         review = process_issues.parse_issue(issue)
         assert review.labels == ["6/pyOS-approved", "another_label"]
+        assert review.active
+
+    # Now add an archive label
+    label_inst = Labels(
+        id=1196238794,
+        node_id="MDU6TGFiZWwxMTk2MjM4Nzk0",
+        url="https://api.github.com/repos/pyOpenSci/software-submission/labels/archived",
+        name="archived",
+        description="",
+        color="006B75",
+        default=False,
+    )
+    labels = [label_inst, "another_label"]
+    for issue in issue_list:
+        issue.labels = labels
+        review = process_issues.parse_issue(issue)
+        assert not review.active


### PR DESCRIPTION
For https://github.com/pyOpenSci/pyopensci.github.io/issues/320

This adds a new `active: bool = True` field to the `ReviewModel` class to track whether a package/review is archived or not. All reviews default to an `active=True` status and are only set to `active=False` if the `archived` label is applied to the original review.

In tandem with these changes, I've added a new "archived" label in the software-submissions repository. You can view this label and currently archived packages here: https://github.com/pyOpenSci/software-submission/issues?q=label%3Aarchived

If that specific label is applied to a review, then each time the pyosMeta `update-reviews` routine is run, it will discover that and set the `active` status to `False`