### PR TITLE
[hotfix] handle packages that lack a description on GitHub

### DIFF
--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -48,6 +48,7 @@ def main():
         print("-" * 20)
 
     # Update gh metrics via api for all packages
+    print("Getting GitHub metrics for all packages...")
     repo_endpoints = process_review.get_repo_endpoints(accepted_reviews)
     all_reviews = process_review.get_gh_metrics(
         repo_endpoints, accepted_reviews

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -190,7 +190,7 @@ class PersonModel(BaseModel, UrlValidatorMixin):
 
 class GhMeta(BaseModel, UrlValidatorMixin):
     name: str
-    description: str
+    description: Optional[str]
     created_at: str
     stargazers_count: int
     watchers_count: int

--- a/src/pyosmeta/parse_issues.py
+++ b/src/pyosmeta/parse_issues.py
@@ -423,6 +423,7 @@ class ProcessIssues:
         pkg_meta = {}
         # url is the api endpoint for a specific pyos-reviewed package repo
         for pkg_name, url in endpoints.items():
+            print(f"Processing review {pkg_name}")
             pkg_meta[pkg_name] = self.process_repo_meta(url)
 
             # These 2 lines both hit the API directly


### PR DESCRIPTION
Hotfix for https://github.com/pyOpenSci/pyopensci.github.io/issues/560

The issue is that astrodata does not have a description on GitHub so the API returns `null` and our `GhMeta` Pydantic model requires this field be set to some string. Considering that repositories on GitHub don't have to have a description, I have changed the description field to be optional.

I also added a few other print statements to our routines to make it a little ore obvious what is going on. A few people had looked at the CI logs and thought Earthpy must be the issue since it was the last logged package. However that was from the previous processing step and the gh-metrics step was running across all packages without any indication.

This PR is meant as a hotfix to get CI back up and running but there are a few things I want to do to improve this which I will post in https://github.com/pyOpenSci/pyopensci.github.io/issues/560