### PR TITLE
Update CHANGELOG.md for 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ## [Unreleased]
 
+## [v1.6] 2025-01-17
+
+
 ## [v1.5] - 2025-01-14
 
 * Fix: Parse archive and JOSS links to handle markdown links and validate DOI links are valid. Added python-doi as a dependency to ensure archive/DOI URLs fully resolve (@banesullivan)
 * Add: new `active` status under `ReviewModel` which is set to `False` if the `"archived"` label is present on a review to mark the package as inactive (@banesullivan)
 
-[v1.4] - 2024-11-22
+## [v1.4] - 2024-11-22
 
 
 * Fix: Parse archive and JOSS links to handle markdown links and validate DOI links are valid. Added python-doi as a dependency to ensure archive/DOI URLs fully resolve (@banesullivan)
@@ -162,7 +165,7 @@ This release was tagged in git and GitHub but not released to PyPI.
 
 Initial release to PyPI.
 
-[Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v0.1.5...HEAD
 [v0.2.4]: https://github.com/pyopensci/pyosmeta/compare/v0.2.3...v0.2.4
 [v0.2.3]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.3
 [v0.2.2]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,9 +166,9 @@ This release was tagged in git and GitHub but not released to PyPI.
 
 Initial release to PyPI.
 
-[Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v0.1.6...HEAD
-[v1.6]: https://github.com/pyopensci/pyosmeta/compare/v0.1.5...v0.1.6
-[v1.5]: https://github.com/pyopensci/pyosmeta/compare/v0.1.4...v0.1.5
+[Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v1.6...HEAD
+[v1.6]: https://github.com/pyopensci/pyosmeta/compare/v1.5...v1.6
+[v1.5]: https://github.com/pyopensci/pyosmeta/compare/v1.4...v1.5
 [v0.2.4]: https://github.com/pyopensci/pyosmeta/compare/v0.2.3...v0.2.4
 [v0.2.3]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.3
 [v0.2.2]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased]
 
-## [v1.6] 2025-01-17
+## [v1.6] - 2025-01-17
 
 
 ## [v1.5] - 2025-01-14
@@ -13,7 +13,6 @@
 * Add: new `active` status under `ReviewModel` which is set to `False` if the `"archived"` label is present on a review to mark the package as inactive (@banesullivan)
 
 ## [v1.4] - 2024-11-22
-
 
 * Fix: Parse archive and JOSS links to handle markdown links and validate DOI links are valid. Added python-doi as a dependency to ensure archive/DOI URLs fully resolve (@banesullivan)
 
@@ -167,6 +166,7 @@ Initial release to PyPI.
 
 [Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v0.1.6...HEAD
 [v1.6]: https://github.com/pyopensci/pyosmeta/compare/v0.1.5...v0.1.6
+[v1.5]: https://github.com/pyopensci/pyosmeta/compare/v0.1.4...v0.1.5
 [v0.2.4]: https://github.com/pyopensci/pyosmeta/compare/v0.2.3...v0.2.4
 [v0.2.3]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.3
 [v0.2.2]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 [![PyPI](https://img.shields.io/pypi/v/pyosmeta.svg)](https://pypi.org/project/pyosmeta/)
 
+See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for additional information.
+
 ## [Unreleased]
 
-## [v1.6] - 2025-01-17
+## [v1.6] - 2025-02-17
 
 
 ## [v1.5] - 2025-01-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,8 @@ This release was tagged in git and GitHub but not released to PyPI.
 
 Initial release to PyPI.
 
-[Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v0.1.6...HEAD
+[v1.6]: https://github.com/pyopensci/pyosmeta/compare/v0.1.5...v0.1.6
 [v0.2.4]: https://github.com/pyopensci/pyosmeta/compare/v0.2.3...v0.2.4
 [v0.2.3]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.3
 [v0.2.2]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,8 @@ Initial release to PyPI.
 [Unreleased]: https://github.com/pyopensci/pyosmeta/compare/v1.6...HEAD
 [v1.6]: https://github.com/pyopensci/pyosmeta/compare/v1.5...v1.6
 [v1.5]: https://github.com/pyopensci/pyosmeta/compare/v1.4...v1.5
+
+<!--- Historical versioning: prior to automation -->
 [v0.2.4]: https://github.com/pyopensci/pyosmeta/compare/v0.2.3...v0.2.4
 [v0.2.3]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.3
 [v0.2.2]: https://github.com/pyopensci/pyosmeta/compare/v0.15...v0.2.2


### PR DESCRIPTION
I went light on the detail of changes other than to add a link which will capture content after v1.6 lands.

We can lean on the GitHub release notes for now for additional detail and I've linked to it from the top of the changelog.