### PR TITLE
[Hotfix] update reviews script fail on error

### DIFF
--- a/src/pyosmeta/cli/process_reviews.py
+++ b/src/pyosmeta/cli/process_reviews.py
@@ -44,6 +44,8 @@ def main():
         print(f"Error in review at url: {url}")
         print(error)
         print("-" * 20)
+    if len(errors):
+        raise RuntimeError("Errors in parsing reviews, see printout above")
 
     # Update gh metrics via api for all packages
     # Contrib count is only available via rest api

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -133,8 +133,6 @@ class GitHubAPI:
         If the remaining requests are exhausted, it calculates the time
         until the rate limit resets and sleeps accordingly.
         """
-        print("hello there")
-
         if "X-RateLimit-Remaining" in response.headers:
             remaining_requests = int(response.headers["X-RateLimit-Remaining"])
             if remaining_requests <= 0:


### PR DESCRIPTION
Hot fix to have the `update-reviews` script fail on CI if errors are encountered when processing reviews

This is a hotfix in that I want to also update this script to ensure that no package is ever deleted when updating the reviews... that may be more involved

ref https://github.com/pyOpenSci/pyopensci.github.io/pull/599