### PR TITLE
[Proposal] Autofix PRs with pre-commit CI

### DIFF
--- a/.github/workflows/test-update-contribs.yml
+++ b/.github/workflows/test-update-contribs.yml
@@ -30,9 +30,6 @@ jobs:
           update-reviews
           update-review-teams
 
-      - name: run precommit hooks
-        uses: pre-commit/action@v3.0.1
-        continue-on-error: true
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,11 @@
 # To run on all files: pre-commit run --all-files
 
 ci:
-  # pyosMeta disables autofixing of PRs to simplify new contributor experience and cleaner git history
-  autofix_prs: false
-  # Frequency of hook updates
+  autofix_prs: true
+  #skip: [flake8, end-of-file-fixer]
+  autofix_commit_msg: |
+    '[pre-commit.ci 🤖] Apply code format tools to PR'
+  # Update hook versions every quarter (so we don't get hit with weekly update pr's)
   autoupdate_schedule: quarterly
 
 repos:


### PR DESCRIPTION
Same as https://github.com/pyOpenSci/pyopensci.github.io/pull/603

This opts into automatically fixing PRs with pre-commit CI and removes `pre-commit/action` from the GitHub Actions workflows

- The  `pre-commit/action` GitHub Action is in maintenance only mode and they recommend swithing to pre-commit CI
- We previously used `pre-commit/action` to automatically reformat the YAML data files generated during the automated data update jobs.
- This PR will instead have those jobs automatically update the data, then pre-commit will automatically fix the formatting as a second commit.

This will remove the confusing error annotation we're seeing on the data update CI jobs since the pre-commit check technically fails since it reformats the YAML data files after they are generated