### PR TITLE
Only use pre-commit ci autofix on automated PRs

### DIFF
--- a/.github/workflows/test-update-contribs.yml
+++ b/.github/workflows/test-update-contribs.yml
@@ -42,6 +42,8 @@ jobs:
           commit-message: "Update: Contributor & review file update"
           delete-branch: true
           title: Update contributor and review data
+          labels: |
+            pre-commit.ci autofix
         env:
           # Custom token needed to trigger PR checks, as GITHUB_TOKEN won't
           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@
 # To run on all files: pre-commit run --all-files
 
 ci:
-  autofix_prs: true
+  autofix_prs: false
   #skip: [flake8, end-of-file-fixer]
   autofix_commit_msg: |
     '[pre-commit.ci 🤖] Apply code format tools to PR'


### PR DESCRIPTION
Per https://github.com/pyOpenSci/pyosMeta/pull/273#issuecomment-2766668675 only run the autofix pre-commit CI on automated PRs