### PR TITLE
ci: Add zizmor to `pre-commit-config.yaml`

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -5,9 +5,14 @@ on:
     types:
       - labeled
 
+permissions: {}
+
 jobs:
   add-help-wanted:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Add issue to project
         id: add-to-project

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -106,5 +106,5 @@ jobs:
       # sigstore-produced signatures and certificates.
       run: |
         gh release upload
-        '${GITHUB_REF_NAME}' dist/**
+        "$GITHUB_REF_NAME" dist/**
         --repo '${{ github.repository }}'

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -104,7 +104,7 @@ jobs:
       # Upload to GitHub Release using the `gh` CLI.
       # `dist/` contains the built packages, and the
       # sigstore-produced signatures and certificates.
-      run: |
+      run: >-
         gh release upload
         "$GITHUB_REF_NAME" dist/**
         --repo '${{ github.repository }}'

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   # setup build separate from publish
   # See https://github.com/pypa/gh-action-pypi-publish/issues/217#issuecomment-1965727093
@@ -21,6 +24,7 @@ jobs:
           # This fetch element is only important if you are use SCM based
           # versioning (that looks at git tags to gather the version)
           fetch-depth: 100
+          persist-credentials: false
 
       # Need the tags so that setuptools-scm can form a valid version number
       - name: Fetch git tags
@@ -69,7 +73,7 @@ jobs:
       - name: Publish package to PyPI
         # Only publish to real PyPI on release
         if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
   sign-files:
     name: >-
       Sign the Python 🐍 distribution 📦 with Sigstore
@@ -89,7 +93,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46  # v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz
@@ -100,7 +104,7 @@ jobs:
       # Upload to GitHub Release using the `gh` CLI.
       # `dist/` contains the built packages, and the
       # sigstore-produced signatures and certificates.
-      run: >-
+      run: |
         gh release upload
-        '${{ github.ref_name }}' dist/**
+        '${GITHUB_REF_NAME}' dist/**
         --repo '${{ github.repository }}'

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,9 +1,5 @@
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        description: 'A token to run the update-contributors script'
-        required: true
 
 jobs:
   run_update_contributors:

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,5 +1,9 @@
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        description: 'A token to run the update-contributors script'
+        required: true
 
 jobs:
   run_update_contributors:
@@ -22,5 +26,5 @@ jobs:
 
       - name: Run script from update-web-metadata repo
         env:
-         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: update-contributors

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -26,5 +26,5 @@ jobs:
 
       - name: Run script from update-web-metadata repo
         env:
-         GITHUB_TOKEN: ${{ secrets.gh_token }}
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: update-contributors

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,7 +1,7 @@
 on:
   workflow_call:
     secrets:
-      github_token:
+      gh_token:
         description: 'The GitHub token used to run the update-contributors script'
         required: true
 
@@ -26,5 +26,5 @@ jobs:
 
       - name: Run script from update-web-metadata repo
         env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         GITHUB_TOKEN: ${{ secrets.gh_token }}
         run: update-contributors

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,5 +1,9 @@
 on:
   workflow_call:
+    secrets:
+      github_token:
+        description: 'The GitHub token used to run the update-contributors script'
+        required: true
 
 jobs:
   run_update_contributors:

--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,12 +1,8 @@
 on:
   workflow_call:
-    inputs:
-      script_name_with_args:
-        required: true
-        type: string
 
 jobs:
-  run_script_job:
+  run_update_contributors:
     runs-on: ubuntu-latest
     steps:
       # TODO: consider replacing python/pip/update-web-metadata installs with docker image
@@ -21,7 +17,10 @@ jobs:
 
       - name: Check out the code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Run script from update-web-metadata repo
         env:
          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: ${{ inputs.script_name_with_args }}
+        run: update-contributors

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,11 +9,10 @@ on:
     # Runs on Mon and Thu of each week at 00:00 UTC (see https://crontab.guru)
     - cron: "0 0 * * 1,4"
 
+permissions: {}
+
 jobs:
   build:
-    permissions:
-      contents: write  # this permission is mandatory for modifying GitHub Releases
-      id-token: write  # this permission is mandatory for PyPI publishing and sigstore
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,15 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write  # this permission is mandatory for modifying GitHub Releases
+      id-token: write  # this permission is mandatory for PyPI publishing and sigstore
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -36,7 +42,7 @@ jobs:
           update-reviews
           update-review-teams
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/test-run-script.yml
+++ b/.github/workflows/test-run-script.yml
@@ -1,8 +1,9 @@
 on: push
 
+permissions: {}
+
 jobs:
   test_run_script_job:
     uses: ./.github/workflows/run-script.yml
-    with:
-      script_name_with_args: update-contributors
-    secrets: inherit
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-run-script.yml
+++ b/.github/workflows/test-run-script.yml
@@ -5,3 +5,5 @@ permissions: {}
 jobs:
   test_run_script_job:
     uses: ./.github/workflows/run-script.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-run-script.yml
+++ b/.github/workflows/test-run-script.yml
@@ -6,4 +6,4 @@ jobs:
   test_run_script_job:
     uses: ./.github/workflows/run-script.yml
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-run-script.yml
+++ b/.github/workflows/test-run-script.yml
@@ -5,5 +5,3 @@ permissions: {}
 jobs:
   test_run_script_job:
     uses: ./.github/workflows/run-script.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-run-script.yml
+++ b/.github/workflows/test-run-script.yml
@@ -6,4 +6,4 @@ jobs:
   test_run_script_job:
     uses: ./.github/workflows/run-script.yml
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-update-contribs.yml
+++ b/.github/workflows/test-update-contribs.yml
@@ -5,12 +5,18 @@ on:
   schedule:
     # Runs on the 1 and 15 of each month at 00:00 UTC (see https://crontab.guru)
     - cron: "0 0 1,15 * *"
+
+permissions: {}
+
 jobs:
   run-meta:
     if: github.repository_owner == 'pyopensci'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
+        with:
+          persist-credentials: false
+
         uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -31,7 +37,7 @@ jobs:
           update-review-teams
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
         with:
           add-paths: |
             _data/contributors.yml

--- a/.github/workflows/test-update-contribs.yml
+++ b/.github/workflows/test-update-contribs.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Check out the code
         with:
           persist-credentials: false
-
         uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,9 @@ repos:
     rev: 0.32.1
     hooks:
       - id: check-github-workflows
+
+  # Find common security issues in GitHub Actions workflows
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.7.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
Closes #245 

Added zizmor to the `pre-commit-config.yaml` file and fixed the security issues it raised:
- Pinned some actions using their SHA instead of tag. See [zizmor unpinned-uses remediation](https://docs.zizmor.sh/audits/#remediation_19)
- Set `permissions: {}` at the workflow level to disable all permissions by default. See [zizmor excessive-permissions remediation](https://docs.zizmor.sh/audits/#after_2) 
- Add `persist-credentials: false` under `actions/checkout`. See [zizmor persist-credentials](https://docs.zizmor.sh/audits/#after)
- Removed the `script_name_with_args` input due to [template-injection](https://docs.zizmor.sh/audits/#remediation_17). I looked at the actions and noticed the `test-run-script.yml` file was running the `update-contributors` script recently. Let me know if it runs more than only that script though!
- Define individual secrets required for the reusable workflow instead of using `secrets: inherit`. See [secrets-inherit remediation](https://docs.zizmor.sh/audits/#remediation_14)

