### PR TITLE
Fix: remove sigstore step from publish build as it's duplicate

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -72,4 +72,4 @@ jobs:
       - name: Publish package to PyPI
         # Only publish to PyPI on release
         if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -64,47 +64,12 @@ jobs:
     permissions:
       id-token: write  # this permission is mandatory for pypi publishing
     steps:
-      # Version 4 doesn't support github enterprise yet
       - name: Download all the dists
         uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
       - name: Publish package to PyPI
-        # Only publish to real PyPI on release
+        # Only publish to PyPI on release
         if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
-  sign-files:
-    name: >-
-      Sign the Python 🐍 distribution 📦 with Sigstore
-      and upload them to GitHub Release
-    # Only sign on release
-    if: github.repository_owner == 'pyopensci' && github.event_name == 'release'
-    needs:
-    - publish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write  # this permission is mandatory for modifying GitHub Releases
-      id-token: write  # this permission is mandatory for sigstore
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46  # v3.0.0
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        "$GITHUB_REF_NAME" dist/**
-        --repo '${{ github.repository }}'
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,21 @@ See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for a
 
 ## [Unreleased]
 
+* Fix: remove sigstore from pypi publish workflow (@lwasser, #286)
+
 ## [v1.7] - 2025-05-19
 
 ### Added
+
 * Added `tqdm` as a dependency to improve progress monitoring when running data processing scripts (@banesullivan)
 * Test missing community partnerships section (@banesullivan, #268)
 * enh: use graphql to consolidate api calls by (@lwasser, #267)
-* Consistent logging by @banesullivan in https://github.com/pyOpenSci/pyosMeta/pull/270
+* Consistent logging by @banesullivan in <https://github.com/pyOpenSci/pyosMeta/pull/270>
 * enh(ci): Add zizmor to `pre-commit-config.yaml` (@klmcadams, #283)
 * enh(docs): Docstrings to docs (@mrgah, #281)
 
 ### Fixed
+
 * Use a consistent logger for informational/debug outputs. Using print statements can make it tough to track down which line of code emitted the message and using the `warnings` module will suppress recurring warnings (@banesullivan)
 * Fix: update deprecated sigstore action by (@lwasser, #265)
 * Remove duplicate "Add help-wanted issues to help wanted board" job by (@banesullivan, #269)
@@ -25,23 +29,25 @@ See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for a
 * enh(docs): update pyosmeta release workflow docs (@lwasser, #278)
 
 ## Thank you!! New Contributors to this release ✨
+
 @klmcadams, @mrgah
 
 ## [v1.6] - 2025-02-17
 
 ## What's Changed
 
-* [hotfix] handle packages that lack a description on GitHub by @banesullivan in https://github.com/pyOpenSci/pyosMeta/pull/257
-* In CONTRIBUTING.md, add more specifics on configuring API token #194 by @hariprakash619 in https://github.com/pyOpenSci/pyosMeta/pull/255
-* docs: add hariprakash619 as a contributor for doc by @allcontributors in https://github.com/pyOpenSci/pyosMeta/pull/256
-* Reorder badges and add more CI badges in README by @willingc in https://github.com/pyOpenSci/pyosMeta/pull/258
-* Update CHANGELOG.md for 1.6 by @willingc in https://github.com/pyOpenSci/pyosMeta/pull/260
-* Update contributor and review data by @github-actions in https://github.com/pyOpenSci/pyosMeta/pull/251
-* Update contributor and review data by @github-actions in https://github.com/pyOpenSci/pyosMeta/pull/253
-* Update contributor and review data by @github-actions in https://github.com/pyOpenSci/pyosMeta/pull/262
+* [hotfix] handle packages that lack a description on GitHub by @banesullivan in <https://github.com/pyOpenSci/pyosMeta/pull/257>
+* In CONTRIBUTING.md, add more specifics on configuring API token #194 by @hariprakash619 in <https://github.com/pyOpenSci/pyosMeta/pull/255>
+* docs: add hariprakash619 as a contributor for doc by @allcontributors in <https://github.com/pyOpenSci/pyosMeta/pull/256>
+* Reorder badges and add more CI badges in README by @willingc in <https://github.com/pyOpenSci/pyosMeta/pull/258>
+* Update CHANGELOG.md for 1.6 by @willingc in <https://github.com/pyOpenSci/pyosMeta/pull/260>
+* Update contributor and review data by @github-actions in <https://github.com/pyOpenSci/pyosMeta/pull/251>
+* Update contributor and review data by @github-actions in <https://github.com/pyOpenSci/pyosMeta/pull/253>
+* Update contributor and review data by @github-actions in <https://github.com/pyOpenSci/pyosMeta/pull/262>
 
 ## New Contributors
-* @hariprakash619 made their first contribution in https://github.com/pyOpenSci/pyosMeta/pull/255
+
+* @hariprakash619 made their first contribution in <https://github.com/pyOpenSci/pyosMeta/pull/255>
 
 ## [v1.5] - 2025-01-14
 


### PR DESCRIPTION
closes #286 

This fix removes a duplicate upload to sigstore. The PyPA action by default implements signing. 