### PR TITLE
[patch] support list of eic and editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for a
 
 ## [Unreleased]
 
+* Fix: support multiple editors and EiCs (@banesullivan, #290)
+
 ## [v1.7.1] - 2025-05-20
 
 * Fix: remove sigstore from pypi publish workflow (@lwasser, #286)
-* Fix: support multiple editors and EiCs (@banesullivan, #290)
 
 ## [v1.7] - 2025-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [GitHub releases](https://github.com/pyOpenSci/pyosMeta/releases) page for a
 ## [v1.7.1] - 2025-05-20
 
 * Fix: remove sigstore from pypi publish workflow (@lwasser, #286)
+* Fix: support multiple editors and EiCs (@banesullivan, #290)
 
 ## [v1.7] - 2025-05-19
 

--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -254,8 +254,8 @@ class ReviewModel(BaseModel):
     repository_link: str = Field(..., alias="repository_link_(if_existing)")
     version_submitted: Optional[str] = None
     categories: Optional[list[str]] = None
-    editor: ReviewUser | None = None
-    eic: ReviewUser | None = None
+    editor: ReviewUser | list[ReviewUser] | None = None
+    eic: ReviewUser | list[ReviewUser] | None = None
     reviewers: list[ReviewUser] = Field(default_factory=list)
     archive: str | None = None
     version_accepted: str | None = None

--- a/tests/data/reviews/multiple_editors.txt
+++ b/tests/data/reviews/multiple_editors.txt
@@ -1,0 +1,27 @@
+Submitting Author: Fakename (@fakeauthor)
+All current maintainers: (@fakeauthor1, @fakeauthor2)
+Package Name: fake_package
+One-Line Description of Package: A fake python package
+Repository Link: https://example.com/fakeauthor1/fake_package
+Version submitted: v1.0.0
+EiC: @fakeeic1, @fakeeic2 , @fakeeic3
+Editor: @fakeeditor1 , @fakeeditor2, @fakeeditor3
+Reviewers: @fakereviewer1 , @fakereviewer2, @fakereviewer3
+Reviews Expected By: fake date
+Archive: [![DOI](https://example.com/fakearchive)](https://zenodo.org/records/8415866)
+JOSS DOI: [![DOI](https://example.com/fakearchive)](https://doi.org/10.21105/joss.01450)
+Version accepted: 2.0.0 ([repo](https://example.com/fakeauthor1/fake_package/releases/tag/v2.0.0), [pypi](https://pypi.org/project/fake_project/2.0.0), [archive](https://example.com/fakearchive))
+Date accepted (month/day/year): 06/29/2024
+
+---
+
+## Scope
+
+- [x] I agree to abide by [pyOpenSci's Code of Conduct][PyOpenSciCodeOfConduct] during the review process and in maintaining my package after should it be accepted.
+- [x] I have read and will commit to package maintenance after the review as per the [pyOpenSci Policies Guidelines][Commitment].
+(etc)
+
+## Community Partnerships
+
+- [ ] etc
+- [ ] aaaaaa

--- a/tests/integration/test_parse_issues.py
+++ b/tests/integration/test_parse_issues.py
@@ -134,3 +134,12 @@ def test_missing_community_partnerships(caplog, process_issues, data_file):
     with caplog.at_level(logging.WARNING):
         review = process_issues.parse_issue(review)
     assert "## Community Partnerships not found in the list" in caplog.text
+
+
+def test_multiple_editors_and_eic(process_issues, data_file):
+    """
+    Test handling of issues with multiple editors and EICs.
+    """
+    review = data_file("reviews/multiple_editors.txt", True)
+    review = process_issues.parse_issue(review)
+    assert review.package_name == "fake_package"


### PR DESCRIPTION
I noticed that a number of reviews were failing to parse due to having multiple eic or editors. This fixes that