### PR TITLE
Fix: update metrics repo name

### DIFF
--- a/src/pyosmeta/cli/update_contributors.py
+++ b/src/pyosmeta/cli/update_contributors.py
@@ -49,7 +49,7 @@ def main():
         "pyosmeta",
         "handbook",
         "software-submission",
-        "peer-review-metrics",
+        "metrics",
         "pyosPackage",
         "pyos-sphinx-theme",
         "lessons",


### PR DESCRIPTION
This is a tiny update to ensure the workflow finds our metrics repo (which used to be named peer-review-metrics)