### PR TITLE
fix: contrib types aligned with repos

### DIFF
--- a/src/pyosmeta/cli/update_contributors.py
+++ b/src/pyosmeta/cli/update_contributors.py
@@ -42,18 +42,18 @@ def main():
         update_all = True
 
     repos = [
-        "python-package-guide",
-        "software-peer-review",
-        "pyopensci.github.io",
-        "software-review",
-        "pyosmeta",
-        "handbook",
-        "software-submission",
+        # "python-package-guide",
+        # "software-peer-review",
+        # "pyopensci.github.io",
+        # "software-review",
+        # "pyosmeta",
+        # "handbook",
+        # "software-submission",
         "metrics",
         "pyosPackage",
         "pyos-sphinx-theme",
         "lessons",
-        "pyos-package-template",
+        # "pyos-package-template",
     ]
     json_files = create_paths(repos)
 

--- a/src/pyosmeta/contributors.py
+++ b/src/pyosmeta/contributors.py
@@ -83,13 +83,28 @@ class ProcessContributors:
             Contribution type.
         """
 
-        if "software-peer-review" in json_file:
+        if any(
+            key in json_file
+            for key in ["software-submission", "software-peer-review"]
+        ):
+            # TODO: change this to programs - peer review
             contrib_type = "peer-review-guide"
-        elif "python-package-guide" in json_file:
+        elif any(
+            key in json_file
+            for key in [
+                "python-package-guide",
+                "pyosPackage",
+                "pyos-package-template",
+            ]
+        ):
+            # TODO consider change this to python-packaging
             contrib_type = "package-guide"
+        # TODO: technically packaging guide is open-education too
+        elif "lessons" in json_file:
+            contrib_type = "open-education"
         elif "pyopensci.github.io" in json_file:
             contrib_type = "web-contrib"
-        elif "update-web-metadata" in json_file:
+        elif "pyosMeta" in json_file or "metrics" in json_file:
             contrib_type = "code-contrib"
         else:
             contrib_type = "community"
@@ -151,6 +166,7 @@ class ProcessContributors:
         for json_file in self.json_files:
             # Process the JSON file and add the data to the combined dictionary
             try:
+                # Steven is still in the list here
                 key, users = self.process_json_file(json_file)
                 combined_data[key] = users
             except Exception:


### PR DESCRIPTION
This begins to address #295 
When going through the code, the contrib_type is based on the repo they contributed to. however in this case, the repo names were dated and in some cases missing so i've fixed that. 