### PR TITLE
[Patch] bypass repository metrics when not hosted on GitHub

### DIFF
--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -326,6 +326,12 @@ class GitHubAPI:
             data = response.json()
             repo_data = data["data"]["repository"]
 
+            if repo_data is None:
+                logger.warning(
+                    f"Repository metrics not able to be retrieved (it may not be on GitHub?): {repo_info['owner']}/{repo_info['repo_name']}."
+                )
+                return None
+
             return {
                 "name": repo_data["name"],
                 "description": repo_data["description"],
@@ -381,7 +387,8 @@ class GitHubAPI:
         If the repository is not found or access is forbidden, it returns None.
         """
         metrics = self._get_metrics_graphql(repo_info)
-        metrics["contrib_count"] = self._get_contrib_count_rest(repo_info)
+        if metrics is not None:
+            metrics["contrib_count"] = self._get_contrib_count_rest(repo_info)
 
         return metrics
 

--- a/src/pyosmeta/github_api.py
+++ b/src/pyosmeta/github_api.py
@@ -326,7 +326,7 @@ class GitHubAPI:
             data = response.json()
             repo_data = data["data"]["repository"]
 
-            if repo_data is None:
+            if not repo_data:
                 logger.warning(
                     f"Repository metrics not able to be retrieved (it may not be on GitHub?): {repo_info['owner']}/{repo_info['repo_name']}."
                 )


### PR DESCRIPTION
GREOPy (https://github.com/pyOpenSci/software-submission/issues/227) was accepted 2 days ago. It is one of the first few packages who's repository is not hosted on GitHub (hosted at https://codeberg.org/JPHackstein/GREOPy) which means we cannot collect metrics for it (stars, issues count, etc). We'd need to implement a mechanism specific to the hosting service to collect metrics like these (specifically https://codeberg.org/ in this case)

This PR bypasses collecting metrics for repositories that are not hosted on GitHub until we can get around to creating a mechanism that would collect these metrics from sites other than GitHub