### PR TITLE
Change reviewers field to be optional

### DIFF
--- a/src/pyosmeta/models/base.py
+++ b/src/pyosmeta/models/base.py
@@ -256,7 +256,7 @@ class ReviewModel(BaseModel):
     categories: Optional[list[str]] = None
     editor: ReviewUser | list[ReviewUser] | None = None
     eic: ReviewUser | list[ReviewUser] | None = None
-    reviewers: list[ReviewUser] = Field(default_factory=list)
+    reviewers: list[ReviewUser] | None = None
     archive: str | None = None
     version_accepted: str | None = None
     date_accepted: str | None = Field(


### PR DESCRIPTION
Our contributor build for the website is broken because we have a package that was accepted via our new JOSS fast track process! (see the new policy pr here https://github.com/pyOpenSci/software-peer-review/pull/342/files) 

This change updates `reviewers` to accept `None` and defaults to it instead of an empty list.

If there are downstream consequences for the change to the default, I'm happy to implement handling thereof, or revert to empty list.